### PR TITLE
Add support for managing escalation policy attachments

### DIFF
--- a/pagerduty/team.go
+++ b/pagerduty/team.go
@@ -105,3 +105,15 @@ func (s *TeamService) AddUser(teamID, userID string) (*Response, error) {
 	u := fmt.Sprintf("/teams/%s/users/%s", teamID, userID)
 	return s.client.newRequestDo("PUT", u, nil, nil, nil)
 }
+
+// RemoveEscalationPolicy removes an escalation policy from a team.
+func (s *TeamService) RemoveEscalationPolicy(teamID, escID string) (*Response, error) {
+	u := fmt.Sprintf("/teams/%s/escalation_policies/%s", teamID, escID)
+	return s.client.newRequestDo("DELETE", u, nil, nil, nil)
+}
+
+// AddEscalationPolicy adds an escalation policy to a team.
+func (s *TeamService) AddEscalationPolicy(teamID, escID string) (*Response, error) {
+	u := fmt.Sprintf("/teams/%s/escalation_policies/%s", teamID, escID)
+	return s.client.newRequestDo("PUT", u, nil, nil, nil)
+}

--- a/pagerduty/team_test.go
+++ b/pagerduty/team_test.go
@@ -162,3 +162,29 @@ func TestTeamsRemoveUser(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestTeamsAddEscalationPolicy(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/teams/1/escalation_policies/1", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+	})
+
+	if _, err := client.Teams.AddEscalationPolicy("1", "1"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestTeamsRemoveEscalationPolicy(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/teams/1/escalation_policies/1", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+	})
+
+	if _, err := client.Teams.RemoveEscalationPolicy("1", "1"); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
This PR adds support for managing escalation policy attachments for a team