### PR TITLE
Make AcknowledgementTimeout and AutoResolveTimeout fields integer pointers

### DIFF
--- a/pagerduty/service.go
+++ b/pagerduty/service.go
@@ -60,10 +60,10 @@ type Integration struct {
 
 // Service represents a service.
 type Service struct {
-	AcknowledgementTimeout int                        `json:"acknowledgement_timeout"`
+	AcknowledgementTimeout *int                       `json:"acknowledgement_timeout"`
 	Addons                 []*AddonReference          `json:"addons,omitempty"`
 	AlertCreation          string                     `json:"alert_creation,omitempty"`
-	AutoResolveTimeout     int                        `json:"auto_resolve_timeout"`
+	AutoResolveTimeout     *int                       `json:"auto_resolve_timeout"`
 	CreatedAt              string                     `json:"created_at,omitempty"`
 	Description            string                     `json:"description,omitempty"`
 	EscalationPolicy       *EscalationPolicyReference `json:"escalation_policy,omitempty"`


### PR DESCRIPTION
Make AcknowledgementTimeout and AutoResolveTimeout fields integer pointers to allow for "null" value which means disabled as documented at https://v2.developer.pagerduty.com/v2/page/api-reference#!/Services/post_services

Resolves terraform-providers/terraform-provider-pagerduty#51