### PR TITLE
Manage extension configuration as plain JSON

### DIFF
--- a/pagerduty/extension.go
+++ b/pagerduty/extension.go
@@ -18,6 +18,7 @@ type Extension struct {
 	EndpointURL      string                    `json:"endpoint_url,omitempty"`
 	ExtensionObjects []*ServiceReference       `json:"extension_objects,omitempty"`
 	ExtensionSchema  *ExtensionSchemaReference `json:"extension_schema"`
+	Config           interface{}               `json:"config,omitempty"`
 }
 
 // ListExtensionsOptions represents options when listing extensions.


### PR DESCRIPTION
This allows to manage the configuration of extensions.

I've got an example here with Slack extension: https://github.com/pdecat/terraform-provider-pagerduty/commit/ed531c38b45898a21e41f97289f46b18acd92a3d#diff-88dbff91359cd2b53c89698836a283cbR182
Note: OAuth authorization still needs be done by hand.

I'm prepping a PR for the terraform part.