### PR TITLE
Fix removing teams from escalation policy

### DIFF
--- a/pagerduty/escalation_policy.go
+++ b/pagerduty/escalation_policy.go
@@ -26,7 +26,7 @@ type EscalationPolicy struct {
 	Self             string              `json:"self,omitempty"`
 	Services         []*ServiceReference `json:"services,omitempty"`
 	Summary          string              `json:"summary,omitempty"`
-	Teams            []*TeamReference    `json:"teams,omitempty"`
+	Teams            []*TeamReference    `json:"teams"`
 	Type             string              `json:"type,omitempty"`
 }
 

--- a/pagerduty/escalation_policy_test.go
+++ b/pagerduty/escalation_policy_test.go
@@ -129,3 +129,29 @@ func TestEscalationPoliciesUpdate(t *testing.T) {
 		t.Errorf("returned \n\n%#v want \n\n%#v", resp, want)
 	}
 }
+
+func TestEscalationPoliciesUpdateTeams(t *testing.T) {
+	setup()
+	defer teardown()
+
+	input := &EscalationPolicy{
+		Name:  "foo",
+		ID:    "1",
+		Teams: []*TeamReference{},
+	}
+
+	mux.HandleFunc("/escalation_policies/1", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		v := new(EscalationPolicy)
+		json.NewDecoder(r.Body).Decode(v)
+		if !reflect.DeepEqual(v.EscalationPolicy, input) {
+			t.Errorf("Request body = %+v, want %+v", v, input)
+		}
+		w.Write([]byte(`{"escalation_policy": {"name": "foo", "id": "1", "teams": []}}`))
+	})
+
+	_, _, err := client.EscalationPolicies.Update("1", input)
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
To remove teams from escalation policy you need to send empty array, but with `omitempty` it was not possible.

One example where this fix is needed - https://github.com/terraform-providers/terraform-provider-pagerduty/pull/129