### PR TITLE
feature: Support setting user's role on a team

### DIFF
--- a/pagerduty/team.go
+++ b/pagerduty/team.go
@@ -36,6 +36,10 @@ type ListTeamsResponse struct {
 	Teams  []*Team `json:"teams,omitempty"`
 }
 
+type teamRole struct {
+	Role string `json:"role,omitempty"`
+}
+
 // List lists existing teams.
 func (s *TeamService) List(o *ListTeamsOptions) (*ListTeamsResponse, *Response, error) {
 	u := "/teams"
@@ -104,6 +108,27 @@ func (s *TeamService) RemoveUser(teamID, userID string) (*Response, error) {
 func (s *TeamService) AddUser(teamID, userID string) (*Response, error) {
 	u := fmt.Sprintf("/teams/%s/users/%s", teamID, userID)
 	return s.client.newRequestDo("PUT", u, nil, nil, nil)
+}
+
+// AddUserWithRole adds a user with the specified role (one of observer, manager, or responder[default])
+func (s *TeamService) AddUserWithRole(teamID, userID string, role string) (*Response, error) {
+	tr := new(teamRole)
+
+	switch role {
+	case "manager":
+		tr = &teamRole{Role: "manager"}
+	case "observer":
+		tr = &teamRole{Role: "observer"}
+	case "responder":
+		tr = &teamRole{Role: "responder"}
+	case "":
+		tr = &teamRole{Role: "responder"}
+	default:
+		tr = nil
+	}
+
+	u := fmt.Sprintf("/teams/%s/users/%s", teamID, userID)
+	return s.client.newRequestDo("PUT", u, nil, tr, nil)
 }
 
 // RemoveEscalationPolicy removes an escalation policy from a team.

--- a/pagerduty/team.go
+++ b/pagerduty/team.go
@@ -112,21 +112,7 @@ func (s *TeamService) AddUser(teamID, userID string) (*Response, error) {
 
 // AddUserWithRole adds a user with the specified role (one of observer, manager, or responder[default])
 func (s *TeamService) AddUserWithRole(teamID, userID string, role string) (*Response, error) {
-	tr := new(teamRole)
-
-	switch role {
-	case "manager":
-		tr = &teamRole{Role: "manager"}
-	case "observer":
-		tr = &teamRole{Role: "observer"}
-	case "responder":
-		tr = &teamRole{Role: "responder"}
-	case "":
-		tr = &teamRole{Role: "responder"}
-	default:
-		tr = nil
-	}
-
+	tr := teamRole{Role: role}
 	u := fmt.Sprintf("/teams/%s/users/%s", teamID, userID)
 	return s.client.newRequestDo("PUT", u, nil, tr, nil)
 }

--- a/pagerduty/team_test.go
+++ b/pagerduty/team_test.go
@@ -150,6 +150,31 @@ func TestTeamsAddUser(t *testing.T) {
 	}
 }
 
+func TestTeamsAddUserWithRole(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/teams/1/users/1", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+	})
+
+	if _, err := client.Teams.AddUserWithRole("1", "1", "responder"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.Teams.AddUserWithRole("1", "1", "observer"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.Teams.AddUserWithRole("1", "1", "manager"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.Teams.AddUserWithRole("1", "1", ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.Teams.AddUserWithRole("1", "1", "garbage"); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestTeamsRemoveUser(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
I am hoping to extend the PagerDuty Terraform provider to allow me to set a member's role on the team. This is the first step.