### PR TITLE
adding event_rules endpoint and user-agent header

### DIFF
--- a/pagerduty/event_rule.go
+++ b/pagerduty/event_rule.go
@@ -1,0 +1,70 @@
+package pagerduty
+
+import "fmt"
+
+// EventRuleService handles the communication with event rules
+// related methods of the PagerDuty API.
+type EventRuleService service
+
+// EventRule represents an event rule.
+type EventRule struct {
+	Actions           []interface{} `json:"actions,omitempty"`
+	AdvancedCondition []interface{} `json:"advanced_condition,omitempty"`
+	CatchAll          bool          `json:"catch_all,omitempty"`
+	Condition         []interface{} `json:"condition,omitempty"`
+	ID                string        `json:"id,omitempty"`
+	Options           []interface{} `json:"options,omitempty"`
+}
+
+// ListEventRulesResponse represents a list response of event rules.
+type ListEventRulesResponse struct {
+	ExternalID    string       `json:"external_id,omitempty"`
+	ObjectVersion string       `json:"object_version,omitempty"`
+	FormatVersion int          `json:"format_version,string,omitempty"`
+	EventRules    []*EventRule `json:"rules,omitempty"`
+}
+
+// List lists existing event rules.
+func (s *EventRuleService) List() (*ListEventRulesResponse, *Response, error) {
+	u := "/event_rules"
+	v := new(ListEventRulesResponse)
+
+	resp, err := s.client.newRequestDo("GET", u, nil, nil, &v)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v, resp, nil
+}
+
+// Create creates a new escalation policy.
+func (s *EventRuleService) Create(eventRule *EventRule) (*EventRule, *Response, error) {
+	u := "/event_rules"
+	v := new(EventRule)
+
+	resp, err := s.client.newRequestDo("POST", u, nil, eventRule, v)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v, resp, nil
+}
+
+// Delete deletes an existing escalation policy.
+func (s *EventRuleService) Delete(id string) (*Response, error) {
+	u := fmt.Sprintf("/event_rules/%s", id)
+	return s.client.newRequestDo("DELETE", u, nil, nil, nil)
+}
+
+// Update updates an existing escalation policy.
+func (s *EventRuleService) Update(id string, eventRule *EventRule) (*EventRule, *Response, error) {
+	u := fmt.Sprintf("/event_rules/%s", id)
+	v := new(EventRule)
+
+	resp, err := s.client.newRequestDo("PUT", u, nil, eventRule, v)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v, resp, nil
+}

--- a/pagerduty/event_rule_test.go
+++ b/pagerduty/event_rule_test.go
@@ -1,0 +1,85 @@
+package pagerduty
+
+import (
+	"encoding/json"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestEventRuleList(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/event_rules", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		w.Write([]byte(`{"external_id": "1", "object_version": "objVersion", "format_version": 2, "rules":[{"id": "1"}]}`))
+	})
+
+	resp, _, err := client.EventRules.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &ListEventRulesResponse{
+		ExternalID:    "1",
+		ObjectVersion: "objVersion",
+		FormatVersion: 2,
+		EventRules: []*EventRule{
+			{
+				ID: "1",
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(resp, want) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp, want)
+	}
+}
+
+func TestEventRuleCreate(t *testing.T) {
+	setup()
+	defer teardown()
+	input := &EventRule{Actions: []interface{}{[]interface{}{"route", "P5DTL0K"}}, Condition: []interface{}{"and", []interface{}{"contains", []interface{}{"path", "payload", "source"}, "website"}}}
+
+	mux.HandleFunc("/event_rules", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		v := new(EventRule)
+		json.NewDecoder(r.Body).Decode(v)
+		if !reflect.DeepEqual(v, input) {
+			t.Errorf("Request body = %+v, want %+v", v, input)
+		}
+		w.Write([]byte(`{"actions":[["route","P5DTL0K"]],"condition": ["and",["contains",["path","payload","source"],"website"]]}`))
+	})
+
+	resp, _, err := client.EventRules.Create(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &EventRule{
+		Actions:           []interface{}{[]interface{}{"route", "P5DTL0K"}},
+		Condition:         []interface{}{"and", []interface{}{"contains", []interface{}{"path", "payload", "source"}, "website"}},
+		CatchAll:          false,
+		AdvancedCondition: []interface{}(nil),
+		Options:           []interface{}(nil),
+	}
+
+	if !reflect.DeepEqual(resp, want) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp, want)
+	}
+}
+
+func TestEventRuleDelete(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/event_rules/1", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	if _, err := client.EventRules.Delete("1"); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pagerduty/pagerduty.go
+++ b/pagerduty/pagerduty.go
@@ -45,6 +45,7 @@ type Client struct {
 	ExtensionSchemas   *ExtensionSchemaService
 	Users              *UserService
 	Vendors            *VendorService
+	EventRules         *EventRuleService
 }
 
 // Response is a wrapper around http.Response
@@ -61,6 +62,8 @@ func NewClient(config *Config) (*Client, error) {
 	if config.BaseURL == "" {
 		config.BaseURL = defaultBaseURL
 	}
+
+	config.UserAgent = "heimweh/go-pagerduty(terraform)"
 
 	baseURL, err := url.Parse(config.BaseURL)
 	if err != nil {
@@ -84,6 +87,7 @@ func NewClient(config *Config) (*Client, error) {
 	c.Vendors = &VendorService{c}
 	c.Extensions = &ExtensionService{c}
 	c.ExtensionSchemas = &ExtensionSchemaService{c}
+	c.EventRules = &EventRuleService{c}
 
 	return c, nil
 }


### PR DESCRIPTION
This adds support for the `/event_rules` endpoint on the PagerDuty API. There are methods for Create, List, Delete and Update--which are all the methods available from the API at this time. 

Also, this PR sets the User-Agent header to identify the library as it makes calls to the PagerDuty API.