### PR TITLE
Makefile: Update tools and targets (#1)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,10 @@ dist: trusty
 sudo: false
 language: go
 go:
-- "1.10.1"
+- "1.12.4"
+
+env:
+  GO111MODULE=off
 
 install:
 - make tools

--- a/Makefile
+++ b/Makefile
@@ -12,11 +12,9 @@ integration:
 tools:
 	go get -u github.com/robertkrimen/godocdown/godocdown
 	go get -u github.com/kardianos/govendor
-	go get -u honnef.co/go/tools/cmd/gosimple
-	go get -u honnef.co/go/tools/cmd/unused
 	go get -u honnef.co/go/tools/cmd/staticcheck
 	go get -u github.com/client9/misspell/cmd/misspell
-	go get -u github.com/golang/lint/golint
+	go get -u golang.org/x/lint/golint
 
 vendor-status:
 	@govendor status
@@ -32,7 +30,7 @@ lint:
 	@echo -e "$(OK_MSG)"
 
 # check combines all checks into a single command
-check: fmtcheck vet misspell staticcheck simple unused lint vendor-status
+check: fmtcheck vet misspell staticcheck lint vendor-status
 
 # fmt formats Go code.
 fmt:
@@ -47,11 +45,6 @@ webdoc:
 	@sleep 1 && open http://localhost:6060 &
 	@godoc -http=:6060
 
-unused:
-	@echo -n "==> Checking that code complies with unused requirements..."
-	@unused $(GOLIST)
-	@echo -e "$(OK_MSG)"
-
 fmtcheck:
 	@echo -n "==> Checking that code complies with gofmt requirements..."
 	@gofmt_files=$$(gofmt -l $(GOFMT_FILES)) ; if [[ -n "$$gofmt_files" ]]; then \
@@ -65,11 +58,6 @@ fmtcheck:
 misspell:
 	@echo -n "==> Checking for misspelling errors..."
 	@misspell --error $(GOFMT_FILES)
-	@echo -e "$(OK_MSG)"
-
-simple:
-	@echo -n "==> Checking that code complies with gosimple requirements..."
-	@gosimple $(GOLIST)
 	@echo -e "$(OK_MSG)"
 
 staticcheck:

--- a/pagerduty/service.go
+++ b/pagerduty/service.go
@@ -63,6 +63,8 @@ type Service struct {
 	AcknowledgementTimeout *int                       `json:"acknowledgement_timeout"`
 	Addons                 []*AddonReference          `json:"addons,omitempty"`
 	AlertCreation          string                     `json:"alert_creation,omitempty"`
+	AlertGrouping          string                     `json:"alert_grouping,omitempty"`
+	AlertGroupingTimeout   *int                       `json:"alert_grouping_timeout,omitempty"`
 	AutoResolveTimeout     *int                       `json:"auto_resolve_timeout"`
 	CreatedAt              string                     `json:"created_at,omitempty"`
 	Description            string                     `json:"description,omitempty"`

--- a/pagerduty/service_fixtures_test.go
+++ b/pagerduty/service_fixtures_test.go
@@ -1,0 +1,171 @@
+package pagerduty
+
+const (
+	validListServicesJSON = `{
+  "services": [
+    {
+      "id": "PIJ90N7",
+      "summary": "My Application Service",
+      "type": "service",
+      "self": "https://api.pagerduty.com/services/PIJ90N7",
+      "html_url": "https://subdomain.pagerduty.com/services/PIJ90N7",
+      "name": "My Application Service",
+      "description": null,
+      "auto_resolve_timeout": 14400,
+      "acknowledgement_timeout": 600,
+      "created_at": "2015-11-06T11:12:51-05:00",
+      "status": "active",
+      "last_incident_timestamp": null,
+      "alert_creation": "create_alerts_and_incidents",
+      "alert_grouping": "intelligent",
+      "alert_grouping_timeout": null,
+      "integrations": [
+        {
+          "id": "PQ12345",
+          "type": "generic_email_inbound_integration_reference",
+          "summary": "Email Integration",
+          "self": "https://api.pagerduty.com/services/PIJ90N7/integrations/PQ12345",
+          "html_url": "https://subdomain.pagerduty.com/services/PIJ90N7/integrations/PQ12345"
+        }
+      ],
+      "escalation_policy": {
+        "id": "PT20YPA",
+        "type": "escalation_policy_reference",
+        "summary": "Another Escalation Policy",
+        "self": "https://api.pagerduty.com/escalation_policies/PT20YPA",
+        "html_url": "https://subdomain.pagerduty.com/escalation_policies/PT20YPA"
+      },
+      "teams": [
+        {
+          "id": "PQ9K7I8",
+          "type": "team_reference",
+          "summary": "Engineering",
+          "self": "https://api.pagerduty.com/teams/PQ9K7I8",
+          "html_url": "https://subdomain.pagerduty.com/teams/PQ9K7I8"
+        }
+      ],
+      "incident_urgency_rule": {
+        "type": "use_support_hours",
+        "during_support_hours": {
+          "type": "constant",
+          "urgency": "high"
+        },
+        "outside_support_hours": {
+          "type": "constant",
+          "urgency": "low"
+        }
+      },
+      "support_hours": {
+        "type": "fixed_time_per_day",
+        "time_zone": "America/Lima",
+        "start_time": "09:00:00",
+        "end_time": "17:00:00",
+        "days_of_week": [
+          1,
+          2,
+          3,
+          4,
+          5
+        ]
+      },
+      "scheduled_actions": [
+        {
+          "type": "urgency_change",
+          "at": {
+            "type": "named_time",
+            "name": "support_hours_start"
+          },
+          "to_urgency": "high"
+        }
+      ]
+    }
+  ],
+  "limit": 25,
+  "offset": 0,
+  "total": null,
+  "more": false
+}`
+)
+
+var (
+	defaultTestServiceAcknowledgementTimeout = 600
+	defaultAutoResolveTimeout                = 14400
+
+	validListServicesResponse = &ListServicesResponse{
+		Services: []*Service{
+			&Service{
+				AcknowledgementTimeout: &defaultTestServiceAcknowledgementTimeout,
+				Addons:                 nil,
+				AlertCreation:          "create_alerts_and_incidents",
+				AlertGrouping:          "intelligent",
+				AlertGroupingTimeout:   nil,
+				AutoResolveTimeout:     &defaultAutoResolveTimeout,
+				CreatedAt:              "2015-11-06T11:12:51-05:00",
+				Description:            "",
+				EscalationPolicy: &EscalationPolicyReference{
+					HTMLURL: "https://subdomain.pagerduty.com/escalation_policies/PT20YPA",
+					ID:      "PT20YPA",
+					Self:    "https://api.pagerduty.com/escalation_policies/PT20YPA",
+					Summary: "Another Escalation Policy",
+					Type:    "escalation_policy_reference",
+				},
+				HTMLURL: "https://subdomain.pagerduty.com/services/PIJ90N7",
+				ID:      "PIJ90N7",
+				IncidentUrgencyRule: &IncidentUrgencyRule{
+					DuringSupportHours: &IncidentUrgencyType{
+						Type:    "constant",
+						Urgency: "high",
+					},
+					OutsideSupportHours: &IncidentUrgencyType{
+						Type:    "constant",
+						Urgency: "low",
+					},
+					Type:    "use_support_hours",
+					Urgency: "",
+				},
+				Integrations: []*IntegrationReference{
+					{
+						ID:      "PQ12345",
+						Type:    "generic_email_inbound_integration_reference",
+						Summary: "Email Integration",
+						Self:    "https://api.pagerduty.com/services/PIJ90N7/integrations/PQ12345",
+						HTMLURL: "https://subdomain.pagerduty.com/services/PIJ90N7/integrations/PQ12345",
+					},
+				},
+				LastIncidentTimestamp: "",
+				Name:                  "My Application Service",
+				ScheduledActions: []*ScheduledAction{
+					{
+						Type: "urgency_change",
+						At: &At{
+							Type: "named_time",
+							Name: "support_hours_start",
+						},
+						ToUrgency: "high",
+					},
+				},
+				Self:    "https://api.pagerduty.com/services/PIJ90N7",
+				Status:  "active",
+				Summary: "My Application Service",
+				SupportHours: &SupportHours{
+					DaysOfWeek: []int{1, 2, 3, 4, 5},
+					EndTime:    "17:00:00",
+					StartTime:  "09:00:00",
+					TimeZone:   "America/Lima",
+					Type:       "fixed_time_per_day",
+				},
+				Teams: []*TeamReference{
+					{
+						ID:      "PQ9K7I8",
+						Type:    "team_reference",
+						Summary: "Engineering",
+						Self:    "https://api.pagerduty.com/teams/PQ9K7I8",
+						HTMLURL: "https://subdomain.pagerduty.com/teams/PQ9K7I8",
+					},
+				},
+				Type: "service",
+			},
+		},
+		Limit: 25,
+	}
+)

--- a/pagerduty/service_test.go
+++ b/pagerduty/service_test.go
@@ -13,7 +13,7 @@ func TestServicesList(t *testing.T) {
 
 	mux.HandleFunc("/services", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		w.Write([]byte(`{"services": [{"id": "1"}]}`))
+		w.Write([]byte(validListServicesJSON))
 	})
 
 	resp, _, err := client.Services.List(&ListServicesOptions{})
@@ -21,16 +21,8 @@ func TestServicesList(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	want := &ListServicesResponse{
-		Services: []*Service{
-			{
-				ID: "1",
-			},
-		},
-	}
-
-	if !reflect.DeepEqual(resp, want) {
-		t.Errorf("returned \n\n%#v want \n\n%#v", resp, want)
+	if !reflect.DeepEqual(resp, validListServicesResponse) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp, validListServicesResponse)
 	}
 }
 


### PR DESCRIPTION
### Reason for change:

The tools that are being used `gosimple` and `unused` in this repo has been updated and moved, this make the `make tools` to fail when running in this project. Thus, this PR fixes that.

#### Commits history

* Makefile: Update tools and targets

Remove `gosimple` and `unused` tools and targets as they are now
integrated into `staticcheck`

* CI: Update go version in CI from 1.10.1 to 1.12.4

* CI: Set GO111MODULE=off until support for Go modules is enabled

* Makefile: Update path for staticcheck tools