### PR TITLE
Support API for getting team member information

### DIFF
--- a/pagerduty/team.go
+++ b/pagerduty/team.go
@@ -18,6 +18,12 @@ type Team struct {
 	Type        string `json:"type,omitempty"`
 }
 
+// Member represents a team member.
+type Member struct {
+	User *UserReference `json:"user,omitempty"`
+	Role string         `json:"role,omitempty"`
+}
+
 // ListTeamsOptions represents options when listing teams.
 type ListTeamsOptions struct {
 	Limit  int    `url:"limit,omitempty"`
@@ -34,6 +40,24 @@ type ListTeamsResponse struct {
 	Offset int     `json:"offset,omitempty"`
 	Total  int     `json:"total,omitempty"`
 	Teams  []*Team `json:"teams,omitempty"`
+}
+
+// GetMembersOptions represents options when get member informations in team.
+type GetMembersOptions struct {
+	Limit    int      `url:"limit,omitempty"`
+	More     bool     `url:"more,omitempty"`
+	Offset   int      `url:"offset,omitempty"`
+	Total    int      `url:"total,omitempty"`
+	Includes []string `url:"include,omitempty,brackets"`
+}
+
+// GetMembersResponse represents member informations response of a team.
+type GetMembersResponse struct {
+	Limit   int       `json:"limit,omitempty"`
+	More    bool      `json:"more,omitempty"`
+	Offset  int       `json:"offset,omitempty"`
+	Total   int       `json:"total,omitempty"`
+	Members []*Member `json:"members,omitempty"`
 }
 
 type teamRole struct {
@@ -115,6 +139,19 @@ func (s *TeamService) AddUserWithRole(teamID, userID string, role string) (*Resp
 	tr := teamRole{Role: role}
 	u := fmt.Sprintf("/teams/%s/users/%s", teamID, userID)
 	return s.client.newRequestDo("PUT", u, nil, tr, nil)
+}
+
+// GetMembers retrieves information about members on a team.
+func (s *TeamService) GetMembers(teamID string, o *GetMembersOptions) (*GetMembersResponse, *Response, error) {
+	u := fmt.Sprintf("/teams/%s/members", teamID)
+	v := new(GetMembersResponse)
+
+	resp, err := s.client.newRequestDo("GET", u, o, nil, &v)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v, resp, nil
 }
 
 // RemoveEscalationPolicy removes an escalation policy from a team.

--- a/pagerduty/team_test.go
+++ b/pagerduty/team_test.go
@@ -188,6 +188,36 @@ func TestTeamsRemoveUser(t *testing.T) {
 	}
 }
 
+func TestTeamsGetMembers(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/teams/1/members", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		w.Write([]byte(`{"members": [{"user": {"id": "1"}, "role": "manager"}]}`))
+	})
+
+	resp, _, err := client.Teams.GetMembers("1", &GetMembersOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &GetMembersResponse{
+		Members: []*Member{
+			{
+				User: &UserReference{
+					ID: "1",
+				},
+				Role: "manager",
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(resp, want) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp, want)
+	}
+}
+
 func TestTeamsAddEscalationPolicy(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
## WHAT

Add support of [`get_teams_id_members` API](https://api-reference.pagerduty.com/#!/Teams/get_teams_id_members)

Unfortunately, the response schema described in API document is wrong. The real API response is this:

```json
{
  "members": [
    {
      "user": {
        "id": "PSxxxxx",
        "type": "user_reference",
        "summary": "xxx",
        "self": "https://api.pagerduty.com/users/PSxxxxx",
        "html_url": "https://example.pagerduty.com/users/PSxxxxx"
      },
      "role": "manager"
      },
    {
      "user": {
        "id": "PXxxxxx",
        "type": "user_reference",
        "summary": "yyy",
        "self": "https://api.pagerduty.com/users/PXxxxxx",
        "html_url": "https://example.pagerduty.com/users/PXxxxxx"
      },
      "role": "manager"
      },
    {
      "user": {
        "id": "PRxxxxx",
        "type": "user_reference",
        "summary": "zzz",
        "self": "https://api.pagerduty.com/users/PRxxxxx",
        "html_url": "https://example.pagerduty.com/users/PRxxxxx"
      },
      "role": "manager"
    }      
  ],
  "limit": 100,
  "offset": 0,
  "more": false,
  "total": null
}
```

### E2E test

<details>
<summary>test code</summary>

```go
package main

import (
	"fmt"
	"os"

	"github.com/heimweh/go-pagerduty/pagerduty"
)

func main() {
	if len(os.Args) < 2 {
		panic("teamID is required in argument")
	}
	teamID := os.Args[1]

	token := os.Getenv("PAGERDUTY_API_TOKEN")
	if token == "" {
		panic("PAGERDUTY_API_TOKEN is required")
	}

	client, err := pagerduty.NewClient(&pagerduty.Config{Token: token})
	if err != nil {
		panic(err)
	}

	resp, _, err := client.Teams.GetMembers(teamID, &pagerduty.GetMembersOptions{})
	if err != nil {
		panic(err)
	}

	for _, member := range resp.Members {
		fmt.Printf("userID: %s\n", member.User.ID)
		fmt.Printf("role:   %s\n", member.Role)
		fmt.Println("=====")
	}
}
```

</details>

<details>
<summary>result</summary>

IDs are masked here

```sh-session
$ go run pagerduty.go P4xxxxx
userID: PSxxxxx
role:   manager
=====
userID: PXxxxxx
role:   manager
=====
userID: PRxxxxx
role:   manager
=====
```

</details>

## WHY

This API needs to implement the support of team member role in [Terraform PagerDuty Provider](https://github.com/terraform-providers/terraform-provider-pagerduty)