### PR TITLE
Allow notification rules with no delay

### DIFF
--- a/pagerduty/user.go
+++ b/pagerduty/user.go
@@ -15,7 +15,7 @@ type NotificationRule struct {
 	HTMLURL             string                  `json:"html_url,omitempty"`
 	ID                  string                  `json:"id,omitempty"`
 	Self                string                  `json:"self,omitempty"`
-	StartDelayInMinutes int                     `json:"start_delay_in_minutes,omitempty"`
+	StartDelayInMinutes int                     `json:"start_delay_in_minutes"`
 	Summary             string                  `json:"summary,omitempty"`
 	Type                string                  `json:"type,omitempty"`
 	Urgency             string                  `json:"urgency,omitempty"`


### PR DESCRIPTION
Based on [PagerDuty API reference](https://developer.pagerduty.com/api-reference/reference/REST/openapiv3.json/paths/~1users~1%7Bid%7D~1notification_rules~1%7Bnotification_rule_id%7D/put) `start_delay_in_minutes` minimal value is `0`, but currently if I set 0 in my terraform I will get error: `Start delay in minutes cannot be empty`