### PR TITLE
Fix AlertGrouping to allow nil values

### DIFF
--- a/pagerduty/service.go
+++ b/pagerduty/service.go
@@ -63,7 +63,7 @@ type Service struct {
 	AcknowledgementTimeout *int                       `json:"acknowledgement_timeout"`
 	Addons                 []*AddonReference          `json:"addons,omitempty"`
 	AlertCreation          string                     `json:"alert_creation,omitempty"`
-	AlertGrouping          string                     `json:"alert_grouping,omitempty"`
+	AlertGrouping          *string                    `json:"alert_grouping"`
 	AlertGroupingTimeout   *int                       `json:"alert_grouping_timeout,omitempty"`
 	AutoResolveTimeout     *int                       `json:"auto_resolve_timeout"`
 	CreatedAt              string                     `json:"created_at,omitempty"`

--- a/pagerduty/service_fixtures_test.go
+++ b/pagerduty/service_fixtures_test.go
@@ -91,13 +91,14 @@ var (
 	defaultTestServiceAcknowledgementTimeout = 600
 	defaultAutoResolveTimeout                = 14400
 
+	ag                        = "intelligent"
 	validListServicesResponse = &ListServicesResponse{
 		Services: []*Service{
 			&Service{
 				AcknowledgementTimeout: &defaultTestServiceAcknowledgementTimeout,
 				Addons:                 nil,
 				AlertCreation:          "create_alerts_and_incidents",
-				AlertGrouping:          "intelligent",
+				AlertGrouping:          &ag,
 				AlertGroupingTimeout:   nil,
 				AutoResolveTimeout:     &defaultAutoResolveTimeout,
 				CreatedAt:              "2015-11-06T11:12:51-05:00",


### PR DESCRIPTION
According to the PagerDuty API [documentation](https://developer.pagerduty.com/api-reference/reference/REST/openapiv3.json/paths/~1services~1%7Bid%7D/put), the `AlertGrouping` parameter value needs to be set to `null` to disable grouping. The `null` cannot be of any other type - neither `"null"`, `""` or any other value disables alert grouping. Declaring the field explicitly as `string` didn't allow `nil` values to be passed, resulting in users not being able to disable alert grouping using the code from this repository, and – as a result of that – using the Terraform provider.

This is the first part of the changes. The second one needs to be applied to the Terraform provider itself. It's already been [prepared](https://github.com/terraform-providers/terraform-provider-pagerduty/pull/235) and waits for this PR to be merged first.