### PR TITLE
Adding response to Team.Get

### DIFF
--- a/pagerduty/team.go
+++ b/pagerduty/team.go
@@ -103,7 +103,7 @@ func (s *TeamService) Get(id string) (*Team, *Response, error) {
 
 	resp, err := s.client.newRequestDo("GET", u, nil, nil, &v)
 	if err != nil {
-		return nil, nil, err
+		return nil, resp, err
 	}
 
 	return v.Team, resp, nil


### PR DESCRIPTION
Adding `resp` to the return on this error case allows for better error handling on applications using this library.  For us, we want to create a PR to enhance error handling within the terraform pagerduty provider but we need this change to do so.