### PR TITLE
Added all operations for Service Event Rules

### DIFF
--- a/pagerduty/service.go
+++ b/pagerduty/service.go
@@ -85,6 +85,31 @@ type Service struct {
 	Type                   string                     `json:"type,omitempty"`
 }
 
+// ServiceEventRule represents a service event rule
+type ServiceEventRule struct {
+	ID         string                      `json:"id,omitempty"`
+	Self       string                      `json:"self,omitempty"`
+	Disabled   bool                        `json:"disabled,omitempty"`
+	Conditions *RuleConditions             `json:"conditions,omitempty"`
+	TimeFrame  []*RuleTimeFrame            `json:"time_frame,omitempty"`
+	Variables  []*ServiceEventRuleVariable `json:"variables,omitempty"`
+	Position   int                         `json:"position,omitempty"`
+	Actions    *RuleActions                `json:"actions,omitempty"`
+}
+
+// ServiceEventRuleVariable represents a service event rule variable
+type ServiceEventRuleVariable struct {
+	Name       string                             `json:"name,omitempty"`
+	Type       string                             `json:"type,omitempty"`
+	Parameters *ServiceEventRuleVariableParameter `json:"parameters,omitempty"`
+}
+
+// ServiceEventRuleVariableParameter represents a service event rule variable parameter
+type ServiceEventRuleVariableParameter struct {
+	Value string `json:"value"`
+	Path  string `json:"path"`
+}
+
 // GetIntegrationOptions represents options when retrieving a service integration.
 type GetIntegrationOptions struct {
 	Includes []string `url:"include,omitempty,brackets"`
@@ -115,6 +140,23 @@ type ListServicesResponse struct {
 // GetServiceOptions represents options when retrieving a service.
 type GetServiceOptions struct {
 	Includes []string `url:"include,brackets,omitempty"`
+}
+
+// ListServiceEventRuleOptions represents options when retrieving a list of event rules for a service
+type ListServiceEventRuleOptions struct {
+	Limit  int  `json:"limit,omitempty"`
+	More   bool `json:"more,omitempty"`
+	Offset int  `json:"offset,omitempty"`
+	Total  int  `json:"total,omitempty"`
+}
+
+// ListServiceEventRuleResponse represents a list of event rules for a service
+type ListServiceEventRuleResponse struct {
+	Limit      int                 `json:"limit,omitempty"`
+	More       bool                `json:"more,omitempty"`
+	Offset     int                 `json:"offset,omitempty"`
+	Total      int                 `json:"total,omitempty"`
+	EventRules []*ServiceEventRule `json:"rules,omitempty"`
 }
 
 // List lists existing services.
@@ -217,5 +259,63 @@ func (s *ServicesService) UpdateIntegration(serviceID, integrationID string, int
 // DeleteIntegration removes an existing service integration.
 func (s *ServicesService) DeleteIntegration(serviceID, integrationID string) (*Response, error) {
 	u := fmt.Sprintf("/services/%s/integrations/%s", serviceID, integrationID)
+	return s.client.newRequestDo("DELETE", u, nil, nil, nil)
+}
+
+// ListEventRules lists existing service event rules.
+func (s *ServicesService) ListEventRules(serviceID string, o *ListServiceEventRuleOptions) (*ListServiceEventRuleResponse, *Response, error) {
+	u := fmt.Sprintf("/services/%s/rules", serviceID)
+	v := new(ListServiceEventRuleResponse)
+
+	resp, err := s.client.newRequestDo("GET", u, o, nil, &v)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v, resp, nil
+}
+
+// CreateEventRule creates a new service event rule.
+func (s *ServicesService) CreateEventRule(serviceID string, eventRule *ServiceEventRule) (*ServiceEventRule, *Response, error) {
+	u := fmt.Sprintf("/services/%s/rules", serviceID)
+	v := new(ServiceEventRule)
+
+	resp, err := s.client.newRequestDo("POST", u, nil, eventRule, &v)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v, resp, nil
+}
+
+// GetEventRule retrieves information about a service event rule.
+func (s *ServicesService) GetEventRule(serviceID, ruleID string) (*ServiceEventRule, *Response, error) {
+	u := fmt.Sprintf("/services/%s/rules/%s", serviceID, ruleID)
+	v := new(ServiceEventRule)
+
+	resp, err := s.client.newRequestDo("GET", u, nil, nil, &v)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v, resp, nil
+}
+
+// UpdateEventRule updates an existing service event rule.
+func (s *ServicesService) UpdateEventRule(serviceID, ruleID string, eventRule *ServiceEventRule) (*ServiceEventRule, *Response, error) {
+	u := fmt.Sprintf("/services/%s/rules/%s", serviceID, ruleID)
+	v := new(ServiceEventRule)
+
+	resp, err := s.client.newRequestDo("PUT", u, nil, eventRule, &v)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v, resp, nil
+}
+
+// DeleteEventRule removes an existing service event rule.
+func (s *ServicesService) DeleteEventRule(serviceID, ruleID string) (*Response, error) {
+	u := fmt.Sprintf("/services/%s/rules/%s", serviceID, ruleID)
 	return s.client.newRequestDo("DELETE", u, nil, nil, nil)
 }

--- a/pagerduty/service_fixtures_test.go
+++ b/pagerduty/service_fixtures_test.go
@@ -85,6 +85,53 @@ const (
   "total": null,
   "more": false
 }`
+	validListServiceEventRulesJSON = `{
+  "rules": [
+    {
+      "variables": [],
+      "time_frame": null,
+      "self": "https://api.pagerduty.com/services/PIJ90N7/rules/503c11f8-9b40-4a8a-b67a-45042d397212",
+      "position": 0,
+      "id": "503c11f8-9b40-4a8a-b67a-45042d397212",
+      "disabled": false,
+      "conditions": {
+        "subconditions": [
+          {
+            "parameters": {
+              "value": "my-app-event-fail",
+              "path": "custom_details.AlarmName"
+            },
+            "operator": "equals"
+          }
+        ],
+        "operator": "and"
+      },
+      "actions": {
+        "suspend": null,
+        "suppress": {
+          "value": true,
+          "threshold_value": null,
+          "threshold_time_unit": null,
+          "threshold_time_amount": null
+        },
+        "severity": {
+          "value": "warning"
+        },
+        "priority": {
+          "value": "PEIZXDR"
+        },
+        "extractions": [],
+        "event_action": null,
+        "automation_actions": [],
+        "annotate": null
+      }
+    }
+  ],
+  "limit": 25,
+  "offset": 0,
+  "total": null,
+  "more": false
+}`
 )
 
 var (
@@ -165,6 +212,41 @@ var (
 					},
 				},
 				Type: "service",
+			},
+		},
+		Limit: 25,
+	}
+	validListServiceEventRuleResponse = &ListServiceEventRuleResponse{
+		EventRules: []*ServiceEventRule{
+			{
+				ID:        "503c11f8-9b40-4a8a-b67a-45042d397212",
+				Self:      "https://api.pagerduty.com/services/PIJ90N7/rules/503c11f8-9b40-4a8a-b67a-45042d397212",
+				Disabled:  false,
+				Variables: []*ServiceEventRuleVariable{},
+				Conditions: &RuleConditions{
+					Operator: "and",
+					RuleSubconditions: []*RuleSubcondition{
+						{
+							Operator: "equals",
+							Parameters: &ConditionParameter{
+								Value: "my-app-event-fail",
+								Path:  "custom_details.AlarmName",
+							},
+						},
+					},
+				},
+				Actions: &RuleActions{
+					Suppress: &RuleActionSuppress{
+						Value: true,
+					},
+					Severity: &RuleActionParameter{
+						Value: "warning",
+					},
+					Priority: &RuleActionParameter{
+						Value: "PEIZXDR",
+					},
+					Extractions: []*RuleActionExtraction{},
+				},
 			},
 		},
 		Limit: 25,

--- a/pagerduty/service_test.go
+++ b/pagerduty/service_test.go
@@ -232,3 +232,126 @@ func TestServicesDeleteIntegration(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestServicesListEventRule(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/services/1/rules", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		w.Write([]byte(validListServiceEventRulesJSON))
+	})
+
+	resp, _, err := client.Services.ListEventRules("1", &ListServiceEventRuleOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(resp, validListServiceEventRuleResponse) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp, validListServiceEventRuleResponse)
+	}
+}
+
+func TestServicesCreateEventRule(t *testing.T) {
+	setup()
+	defer teardown()
+
+	input := &ServiceEventRule{
+		Position: 99,
+		ID:       "1",
+	}
+
+	mux.HandleFunc("/services/1/rules", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		v := new(ServiceEventRule)
+		json.NewDecoder(r.Body).Decode(v)
+		if !reflect.DeepEqual(v, input) {
+			t.Errorf("Request body = %+v, want %+v", v, input)
+		}
+		w.Write([]byte(`{"id": "1", "position": 99}`))
+	})
+
+	resp, _, err := client.Services.CreateEventRule("1", input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &ServiceEventRule{
+		Position: 99,
+		ID:       "1",
+	}
+
+	if !reflect.DeepEqual(resp, want) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp, want)
+	}
+}
+
+func TestServicesUpdateEventRule(t *testing.T) {
+	setup()
+	defer teardown()
+
+	input := &ServiceEventRule{
+		Position: 99,
+	}
+
+	mux.HandleFunc("/services/1/rules/1", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		v := new(ServiceEventRule)
+		json.NewDecoder(r.Body).Decode(v)
+		if !reflect.DeepEqual(v, input) {
+			t.Errorf("Request body = %+v, want %+v", v, input)
+		}
+		w.Write([]byte(`{"position": 99, "id": "1"}`))
+	})
+
+	resp, _, err := client.Services.UpdateEventRule("1", "1", input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &ServiceEventRule{
+		Position: 99,
+		ID:       "1",
+	}
+
+	if !reflect.DeepEqual(resp, want) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp, want)
+	}
+}
+
+func TestServicesGetEventRule(t *testing.T) {
+	setup()
+	defer teardown()
+	mux.HandleFunc("/services/1/rules/1", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		w.Write([]byte(`{"position": 99, "id": "1"}`))
+	})
+
+	resp, _, err := client.Services.GetEventRule("1", "1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &ServiceEventRule{
+		Position: 99,
+		ID:       "1",
+	}
+
+	if !reflect.DeepEqual(resp, want) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp, want)
+	}
+}
+
+func TestServicesDeleteEventRule(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/services/1/rules/1", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	if _, err := client.Services.DeleteEventRule("1", "1"); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
I have added the Service Event Rules, as they are available in the API, see: https://developer.pagerduty.com/api-reference/docs/CHANGELOG.md#2020-09-16