### PR TITLE
Bumping CI go version to 1.15.6.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ dist: trusty
 sudo: false
 language: go
 go:
-- "1.12.4"
+- "1.15.6"
 
 env:
   GO111MODULE=off


### PR DESCRIPTION
This doesn't reflect the required version of go for `go-pagerduty` itself, but a dependency was having trouble with go versions `< 1.13.X`.

See recent failures: https://travis-ci.org/github/heimweh/go-pagerduty