### PR TITLE
Add AlertGroupingParameters to support schema change

### DIFF
--- a/pagerduty/service.go
+++ b/pagerduty/service.go
@@ -21,6 +21,12 @@ type ScheduledAction struct {
 
 // AlertGroupingParameters are the parameters for configuring alert grouping.
 type AlertGroupingParameters struct {
+	Type   string               `json:"type,omitempty"`
+	Config *AlertGroupingConfig `json:"config,omitempty"`
+}
+
+// AlertGroupingConfig is the config settings for the parameters to configure alert grouping.
+type AlertGroupingConfig struct {
 	Timeout   string   `json:"timeout,omitempty"`
 	Aggregate string   `json:"aggregate,omitempty"`
 	Fields    []string `json:"fields,omitempty"`

--- a/pagerduty/service.go
+++ b/pagerduty/service.go
@@ -78,7 +78,7 @@ type Service struct {
 	AlertCreation           string                     `json:"alert_creation,omitempty"`
 	AlertGrouping           *string                    `json:"alert_grouping"`
 	AlertGroupingTimeout    *int                       `json:"alert_grouping_timeout,omitempty"`
-	AlertGroupingParameters []*AlertGroupingParameters `json:"alert_grouping_parameters,omitempty"`
+	AlertGroupingParameters *AlertGroupingParameters   `json:"alert_grouping_parameters,omitempty"`
 	AutoResolveTimeout      *int                       `json:"auto_resolve_timeout"`
 	CreatedAt               string                     `json:"created_at,omitempty"`
 	Description             string                     `json:"description,omitempty"`

--- a/pagerduty/service.go
+++ b/pagerduty/service.go
@@ -19,6 +19,13 @@ type ScheduledAction struct {
 	Type      string `json:"type,omitempty"`
 }
 
+// AlertGroupingParameters are the parameters for configuring alert grouping.
+type AlertGroupingParameters struct {
+	Timeout   string   `json:"timeout,omitempty"`
+	Aggregate string   `json:"aggregate,omitempty"`
+	Fields    []string `json:"fields,omitempty"`
+}
+
 // IncidentUrgencyType are the incidents urgency during or outside support hours.
 type IncidentUrgencyType struct {
 	Type    string `json:"type,omitempty"`
@@ -60,29 +67,30 @@ type Integration struct {
 
 // Service represents a service.
 type Service struct {
-	AcknowledgementTimeout *int                       `json:"acknowledgement_timeout"`
-	Addons                 []*AddonReference          `json:"addons,omitempty"`
-	AlertCreation          string                     `json:"alert_creation,omitempty"`
-	AlertGrouping          *string                    `json:"alert_grouping"`
-	AlertGroupingTimeout   *int                       `json:"alert_grouping_timeout,omitempty"`
-	AutoResolveTimeout     *int                       `json:"auto_resolve_timeout"`
-	CreatedAt              string                     `json:"created_at,omitempty"`
-	Description            string                     `json:"description,omitempty"`
-	EscalationPolicy       *EscalationPolicyReference `json:"escalation_policy,omitempty"`
-	HTMLURL                string                     `json:"html_url,omitempty"`
-	ID                     string                     `json:"id,omitempty"`
-	IncidentUrgencyRule    *IncidentUrgencyRule       `json:"incident_urgency_rule,omitempty"`
-	Integrations           []*IntegrationReference    `json:"integrations,omitempty"`
-	LastIncidentTimestamp  string                     `json:"last_incident_timestamp,omitempty"`
-	Name                   string                     `json:"name,omitempty"`
-	ScheduledActions       []*ScheduledAction         `json:"scheduled_actions,omitempty"`
-	Self                   string                     `json:"self,omitempty"`
-	Service                *Service                   `json:"service,omitempty"`
-	Status                 string                     `json:"status,omitempty"`
-	Summary                string                     `json:"summary,omitempty"`
-	SupportHours           *SupportHours              `json:"support_hours,omitempty"`
-	Teams                  []*TeamReference           `json:"teams,omitempty"`
-	Type                   string                     `json:"type,omitempty"`
+	AcknowledgementTimeout  *int                       `json:"acknowledgement_timeout"`
+	Addons                  []*AddonReference          `json:"addons,omitempty"`
+	AlertCreation           string                     `json:"alert_creation,omitempty"`
+	AlertGrouping           *string                    `json:"alert_grouping"`
+	AlertGroupingTimeout    *int                       `json:"alert_grouping_timeout,omitempty"`
+	AlertGroupingParameters []*AlertGroupingParameters `json:"alert_grouping_parameters,omitempty"`
+	AutoResolveTimeout      *int                       `json:"auto_resolve_timeout"`
+	CreatedAt               string                     `json:"created_at,omitempty"`
+	Description             string                     `json:"description,omitempty"`
+	EscalationPolicy        *EscalationPolicyReference `json:"escalation_policy,omitempty"`
+	HTMLURL                 string                     `json:"html_url,omitempty"`
+	ID                      string                     `json:"id,omitempty"`
+	IncidentUrgencyRule     *IncidentUrgencyRule       `json:"incident_urgency_rule,omitempty"`
+	Integrations            []*IntegrationReference    `json:"integrations,omitempty"`
+	LastIncidentTimestamp   string                     `json:"last_incident_timestamp,omitempty"`
+	Name                    string                     `json:"name,omitempty"`
+	ScheduledActions        []*ScheduledAction         `json:"scheduled_actions,omitempty"`
+	Self                    string                     `json:"self,omitempty"`
+	Service                 *Service                   `json:"service,omitempty"`
+	Status                  string                     `json:"status,omitempty"`
+	Summary                 string                     `json:"summary,omitempty"`
+	SupportHours            *SupportHours              `json:"support_hours,omitempty"`
+	Teams                   []*TeamReference           `json:"teams,omitempty"`
+	Type                    string                     `json:"type,omitempty"`
 }
 
 // ServiceEventRule represents a service event rule


### PR DESCRIPTION
New supported schema has a parameters object for configuration of alert grouping.
reference: https://developer.pagerduty.com/api-reference/reference/REST/openapiv3.json/paths/~1services/post