### PR TITLE
Caching for users, contact methods and notification rules

### DIFF
--- a/pagerduty/ability.go
+++ b/pagerduty/ability.go
@@ -22,6 +22,11 @@ func (s *AbilityService) List() (*ListAbilitiesResponse, *Response, error) {
 	u := "/abilities"
 	v := new(ListAbilitiesResponse)
 
+	err := cacheGetAbilities(v)
+	if err == nil {
+		return v, nil, nil
+	}
+
 	resp, err := s.client.newRequestDo("GET", u, nil, nil, v)
 	if err != nil {
 		return nil, nil, err

--- a/pagerduty/cache.go
+++ b/pagerduty/cache.go
@@ -369,7 +369,6 @@ func cacheGetAbilities(v interface{}) error {
 	r := new(CacheAbilitiesRecord)
 	err := cacheGet("misc", "abilities", r)
 	if err != nil {
-		log.Printf("===== cacheGetAbilities error: %+v", err)
 		return err
 	}
 	b, _ := json.Marshal(r)

--- a/pagerduty/cache.go
+++ b/pagerduty/cache.go
@@ -1,0 +1,414 @@
+package pagerduty
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/mongo/readpref"
+)
+
+var pdClient *Client
+var cacheType string
+var cacheMongoURL string
+var cacheMaxAge, _ = time.ParseDuration("10s")
+
+var mongoClient *mongo.Client
+
+var mongoCache map[string]*mongo.Collection
+
+var memoryCache = map[string]*sync.Map{
+	"users":              {},
+	"contact_methods":    {},
+	"notification_rules": {},
+	"misc":               {},
+}
+
+type CacheAbilitiesRecord struct {
+	ID        string
+	Abilities *ListAbilitiesResponse
+}
+
+type CacheLastRefreshRecord struct {
+	ID        string
+	Users     time.Time
+	Abilities time.Time
+}
+
+func InitCache(c *Client) {
+	pdClient = c
+	if cacheMongoURL = os.Getenv("TF_PAGERDUTY_CACHE"); strings.HasPrefix(cacheMongoURL, "mongodb://") {
+		log.Printf("===== Enabling PagerDuty Mongo cache at %v", cacheMongoURL)
+		cacheType = "mongo"
+	} else if cacheMongoURL == "memory" {
+		log.Println("===== Enabling PagerDuty memory cache =====")
+		cacheType = "memory"
+		return
+	} else {
+		log.Println("===== PagerDuty Cache Skipping Init =====")
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	mongoClient, _ = mongo.Connect(ctx, options.Client().ApplyURI(cacheMongoURL))
+
+	ctx, cancel = context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	err := mongoClient.Ping(ctx, readpref.Primary())
+	if err != nil {
+		log.Printf("===== PagerDuty Cache couldn't connect to MongoDB at %q, disabling cache =====", cacheMongoURL)
+		cacheType = ""
+		return
+	}
+
+	if os.Getenv("TF_PAGERDUTY_CACHE_MAX_AGE") != "" {
+		d, err := time.ParseDuration(os.Getenv("TF_PAGERDUTY_CACHE_MAX_AGE"))
+		if err != nil {
+			log.Printf("===== PagerDuty Cache couldn't parse max age %q, using the default %v =====", os.Getenv("TF_PAGERDUTY_CACHE_MAX_AGE"), cacheMaxAge)
+		} else {
+			cacheMaxAge = d
+		}
+	}
+
+	mongoCache = map[string]*mongo.Collection{
+		"users":              mongoClient.Database("pagerduty").Collection("users"),
+		"contact_methods":    mongoClient.Database("pagerduty").Collection("contact_methods"),
+		"notification_rules": mongoClient.Database("pagerduty").Collection("notification_rules"),
+		"misc":               mongoClient.Database("pagerduty").Collection("misc"),
+	}
+}
+
+func PopulateMemoryCache() {
+	abilities, _, _ := pdClient.Abilities.List()
+
+	abilitiesRecord := &CacheAbilitiesRecord{
+		ID:        "abilities",
+		Abilities: abilities,
+	}
+	cachePut("misc", "abilities", abilitiesRecord)
+}
+
+func PopulateMongoCache() {
+	filter := bson.D{primitive.E{Key: "ID", Value: "lastrefresh"}}
+	lastRefreshRecord := new(CacheLastRefreshRecord)
+	err := mongoCache["misc"].FindOne(context.TODO(), filter).Decode(lastRefreshRecord)
+	if err == nil {
+		if time.Since(lastRefreshRecord.Users) < cacheMaxAge {
+			log.Printf("===== PagerDuty cache was refreshed at %s, not refreshing =====", lastRefreshRecord.Users.Format(time.RFC3339))
+			return
+		} else {
+			log.Printf("===== PagerDuty cache was refreshed at %s, refreshing =====", lastRefreshRecord.Users.Format(time.RFC3339))
+		}
+	}
+
+	var pdo = ListUsersOptions{
+		Include: []string{"contact_methods", "notification_rules"},
+		Limit:   100,
+	}
+
+	fullUsers, err := pdClient.Users.ListAll(&pdo)
+	if err != nil {
+		log.Println("===== Couldn't load users =====")
+		return
+	}
+
+	users := make([]interface{}, len(fullUsers))
+	var contactMethods []interface{}
+	var notificationRules []interface{}
+	for i := 0; i < len(fullUsers); i++ {
+		user := new(User)
+		b, _ := json.Marshal(fullUsers[i])
+		json.Unmarshal(b, user)
+		users[i] = &user
+
+		for j := 0; j < len(fullUsers[i].ContactMethods); j++ {
+			contactMethods = append(contactMethods, &(fullUsers[i].ContactMethods[j]))
+		}
+
+		for j := 0; j < len(fullUsers[i].NotificationRules); j++ {
+			notificationRules = append(notificationRules, &(fullUsers[i].NotificationRules[j]))
+		}
+	}
+
+	abilities, _, _ := pdClient.Abilities.List()
+
+	abilitiesRecord := &CacheAbilitiesRecord{
+		ID:        "abilities",
+		Abilities: abilities,
+	}
+
+	mongoCache["users"].Drop(context.TODO())
+	if len(users) > 0 {
+		res, err := mongoCache["users"].InsertMany(context.TODO(), users)
+		if err != nil {
+			log.Fatal(err)
+		}
+		log.Printf("Inserted %d users", len(res.InsertedIDs))
+	}
+
+	mongoCache["contact_methods"].Drop(context.TODO())
+	if len(contactMethods) > 0 {
+		res, err := mongoCache["contact_methods"].InsertMany(context.TODO(), contactMethods)
+		if err != nil {
+			log.Fatal(err)
+		}
+		log.Printf("Inserted %d contact methods", len(res.InsertedIDs))
+	}
+
+	mongoCache["notification_rules"].Drop(context.TODO())
+	if len(notificationRules) > 0 {
+		res, err := mongoCache["notification_rules"].InsertMany(context.TODO(), notificationRules)
+		if err != nil {
+			log.Fatal(err)
+		}
+		log.Printf("Inserted %d notification rules", len(res.InsertedIDs))
+	}
+
+	mongoCache["misc"].Drop(context.TODO())
+	ares, err := mongoCache["misc"].InsertOne(context.TODO(), &abilitiesRecord)
+	log.Println(ares)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	cacheLastRefreshRecord := &CacheLastRefreshRecord{
+		ID:        "lastrefresh",
+		Users:     time.Now(),
+		Abilities: time.Now(),
+	}
+	cres, err := mongoCache["misc"].InsertOne(context.TODO(), &cacheLastRefreshRecord)
+	log.Println(cres)
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func PopulateCache() {
+	if cacheType == "mongo" {
+		PopulateMongoCache()
+	} else if cacheType == "memory" {
+		PopulateMemoryCache()
+	}
+}
+
+func getFullUserToCache(id string, v interface{}) error {
+	fu, _, err := pdClient.Users.GetFull(id)
+	if err != nil {
+		log.Printf("===== getFullUserToCache: Error getting user %v from PD: %v", id, err)
+		return err
+	}
+
+	u := new(User)
+	b, _ := json.Marshal(fu)
+	json.Unmarshal(b, u)
+	json.Unmarshal(b, v)
+	err = cachePutUser(u)
+	if err != nil {
+		log.Printf("===== getFullUserToCache: Error putting user %v to cache: %v", id, err)
+		return err
+	} else {
+		log.Printf("===== getFullUserToCache: Put user %v to cache", id)
+	}
+
+	for _, c := range fu.ContactMethods {
+		err = cachePutContactMethod(c)
+		if err != nil {
+			log.Printf("===== getFullUserToCache: Error putting contact method %v to cache: %v", id, err)
+			return err
+		} else {
+			log.Printf("===== getFullUserToCache: Put contact method %v to cache", id)
+		}
+	}
+
+	for _, r := range fu.NotificationRules {
+		err = cachePutNotificationRule(r)
+		if err != nil {
+			log.Printf("===== getFullUserToCache: Error putting notification rule %v to cache: %v", id, err)
+			return err
+		} else {
+			log.Printf("===== getFullUserToCache: Put notification rule %v to cache", id)
+		}
+	}
+	return nil
+}
+
+func memoryCacheGet(collection_name string, id string, v interface{}) error {
+	log.Printf("===== memoryCacheGet %v from %v", id, collection_name)
+	if collection, ok := memoryCache[collection_name]; ok {
+		if item, ok := collection.Load(id); ok {
+			err := json.Unmarshal(item.([]byte), v)
+			if err != nil {
+				log.Printf("===== memoryCacheGet Error unmarshaling JSON getting %v from %q: %v", id, collection_name, err)
+				return err
+			}
+			log.Printf("===== memoryCacheGet Got %v from %q cache", id, collection_name)
+			return nil
+		} else if collection_name == "users" {
+			// special case for filling users into memory cache on demand
+			return getFullUserToCache(id, v)
+		} else {
+			return fmt.Errorf("memoryCacheGet Item %q is not in %q hash", id, collection_name)
+		}
+	} else {
+		return fmt.Errorf("memoryCacheGet No such collection: %q", collection_name)
+	}
+}
+
+func mongoCacheGet(collection_name string, id string, v interface{}) error {
+	if collection, ok := mongoCache[collection_name]; ok {
+		filter := bson.D{primitive.E{Key: "id", Value: id}}
+		r := collection.FindOne(context.TODO(), filter)
+		err := r.Decode(v)
+		if err != nil {
+			return err
+		}
+		return nil
+	} else {
+		return fmt.Errorf("mongoCacheGet No such collection: %q", collection_name)
+	}
+}
+
+func cacheGet(collection_name string, id string, v interface{}) error {
+	if cacheType == "mongo" {
+		return mongoCacheGet(collection_name, id, v)
+	} else if cacheType == "memory" {
+		return memoryCacheGet(collection_name, id, v)
+	} else {
+		return fmt.Errorf("cacheGet Cache is not enabled")
+	}
+}
+
+func mongoCachePut(collection_name string, id string, v interface{}) error {
+	if collection, ok := mongoCache[collection_name]; ok {
+		filter := bson.D{primitive.E{Key: "id", Value: id}}
+		opts := options.Replace().SetUpsert(true)
+		res, err := collection.ReplaceOne(context.TODO(), filter, &v, opts)
+		if err != nil {
+			log.Printf("===== Error updating %v: %q", collection_name, err)
+			return err
+		}
+		if res.MatchedCount != 0 {
+			log.Printf("===== replaced an existing item %q in %v cache", id, collection_name)
+			return nil
+		}
+		if res.UpsertedCount != 0 {
+			log.Printf("===== inserted a new item %q in %v cache", id, collection_name)
+		}
+		return nil
+	} else {
+		return fmt.Errorf("no such collection %q", collection_name)
+	}
+}
+
+func memoryCachePut(collection_name string, id string, v interface{}) error {
+	if collection, ok := memoryCache[collection_name]; ok {
+		b, _ := json.Marshal(v)
+		collection.Store(id, b)
+		return nil
+	} else {
+		return fmt.Errorf("no such collection: %q", collection_name)
+	}
+}
+
+func cachePut(collection_name string, id string, v interface{}) error {
+	if cacheType == "mongo" {
+		return mongoCachePut(collection_name, id, v)
+	} else if cacheType == "memory" {
+		return memoryCachePut(collection_name, id, v)
+	} else {
+		return fmt.Errorf("cachePut Cache is not enabled")
+	}
+}
+
+func mongoCacheDelete(collection_name string, id string) error {
+	if collection, ok := mongoCache[collection_name]; ok {
+		filter := bson.D{primitive.E{Key: "id", Value: id}}
+		_, err := collection.DeleteOne(context.TODO(), filter)
+		if err != nil {
+			log.Printf("===== mongoCacheDelete mongo error: %q", err)
+			return err
+		}
+		log.Printf("===== mongoCacheDetele deleted item %v from %q", id, collection_name)
+		return nil
+	} else {
+		return fmt.Errorf("mongoCacheDelete No such collection %q", collection_name)
+	}
+}
+
+func memoryCacheDelete(collection_name string, id string) error {
+	if collection, ok := memoryCache[collection_name]; ok {
+		collection.Delete(id)
+		log.Printf("===== memoryCacheDelete deleted item %v from %q", id, collection_name)
+		return nil
+	} else {
+		return fmt.Errorf("memoryCacheDelete No such collection: %q", collection_name)
+	}
+}
+
+func cacheDelete(collection_name string, id string) error {
+	if cacheType == "mongo" {
+		return mongoCacheDelete(collection_name, id)
+	} else if cacheType == "memory" {
+		return memoryCacheDelete(collection_name, id)
+	} else {
+		return fmt.Errorf("cacheDelete Cache is not enabled")
+	}
+}
+
+func cacheGetAbilities(v interface{}) error {
+	r := new(CacheAbilitiesRecord)
+	err := cacheGet("misc", "abilities", r)
+	if err != nil {
+		log.Printf("===== cacheGetAbilities error: %+v", err)
+		return err
+	}
+	b, _ := json.Marshal(r)
+	json.Unmarshal(b, v)
+	return nil
+}
+
+func cacheGetUser(id string, v interface{}) error {
+	return cacheGet("users", id, v)
+}
+
+func cachePutUser(u *User) error {
+	return cachePut("users", u.ID, u)
+}
+
+func cacheDeleteUser(id string) error {
+	return cacheDelete("users", id)
+}
+
+func cacheGetContactMethod(id string, v interface{}) error {
+	return cacheGet("contact_methods", id, v)
+}
+
+func cachePutContactMethod(c *ContactMethod) error {
+	return cachePut("contact_methods", c.ID, c)
+}
+
+func cacheDeleteContactMethod(id string) error {
+	return cacheDelete("contact_methods", id)
+}
+
+func cacheGetNotificationRule(id string, v interface{}) error {
+	return cacheGet("notification_rules", id, v)
+}
+
+func cachePutNotificationRule(r *NotificationRule) error {
+	return cachePut("notification_rules", r.ID, r)
+}
+
+func cacheDeleteNotificationRule(id string) error {
+	return cacheDelete("notification_rules", id)
+}

--- a/pagerduty/cache.go
+++ b/pagerduty/cache.go
@@ -270,19 +270,19 @@ func getFullUserToCache(id string, v interface{}) error {
 	for _, c := range fu.ContactMethods {
 		err = cachePutContactMethod(c)
 		if err != nil {
-			log.Printf("===== getFullUserToCache: Error putting contact method %v to cache: %v", id, err)
+			log.Printf("===== getFullUserToCache: Error putting contact method %v to cache: %v", c.ID, err)
 			return err
 		}
-		log.Printf("===== getFullUserToCache: Put contact method %v to cache", id)
+		log.Printf("===== getFullUserToCache: Put contact method %v to cache", c.ID)
 	}
 
 	for _, r := range fu.NotificationRules {
 		err = cachePutNotificationRule(r)
 		if err != nil {
-			log.Printf("===== getFullUserToCache: Error putting notification rule %v to cache: %v", id, err)
+			log.Printf("===== getFullUserToCache: Error putting notification rule %v to cache: %v", r.ID, err)
 			return err
 		}
-		log.Printf("===== getFullUserToCache: Put notification rule %v to cache", id)
+		log.Printf("===== getFullUserToCache: Put notification rule %v to cache", r.ID)
 	}
 	return nil
 }

--- a/pagerduty/pagerduty.go
+++ b/pagerduty/pagerduty.go
@@ -77,7 +77,7 @@ func NewClient(config *Config) (*Client, error) {
 		config.BaseURL = defaultBaseURL
 	}
 
-	config.UserAgent = "heimweh/go-pagerduty(terraform)"
+	config.UserAgent = "heimweh/go-pagerduty(terraform-caching)"
 
 	baseURL, err := url.Parse(config.BaseURL)
 	if err != nil {
@@ -107,6 +107,9 @@ func NewClient(config *Config) (*Client, error) {
 	c.ServiceDependencies = &ServiceDependencyService{c}
 	c.Priorities = &PriorityService{c}
 	c.ResponsePlays = &ResponsePlayService{c}
+
+	InitCache(c)
+	PopulateCache()
 
 	return c, nil
 }

--- a/pagerduty/pagerduty.go
+++ b/pagerduty/pagerduty.go
@@ -77,7 +77,7 @@ func NewClient(config *Config) (*Client, error) {
 		config.BaseURL = defaultBaseURL
 	}
 
-	config.UserAgent = "heimweh/go-pagerduty(terraform-caching)"
+	config.UserAgent = "heimweh/go-pagerduty(terraform)"
 
 	baseURL, err := url.Parse(config.BaseURL)
 	if err != nil {

--- a/pagerduty/user.go
+++ b/pagerduty/user.go
@@ -2,6 +2,7 @@ package pagerduty
 
 import (
 	"fmt"
+	"log"
 )
 
 // UserService handles the communication with user
@@ -41,6 +42,28 @@ type User struct {
 	TimeZone          string                    `json:"time_zone,omitempty"`
 	Type              string                    `json:"type,omitempty"`
 	User              *User                     `json:"user,omitempty"`
+}
+
+// FullUser represents a user fetched with include[]=contact_methods,notification_rules.
+type FullUser struct {
+	AvatarURL         string              `json:"avatar_url,omitempty"`
+	Color             string              `json:"color,omitempty"`
+	ContactMethods    []*ContactMethod    `json:"contact_methods,omitempty"`
+	Description       string              `json:"description,omitempty"`
+	Email             string              `json:"email,omitempty"`
+	HTMLURL           string              `json:"html_url,omitempty"`
+	ID                string              `json:"id,omitempty"`
+	InvitationSent    bool                `json:"invitation_sent,omitempty"`
+	JobTitle          string              `json:"job_title,omitempty"`
+	Name              string              `json:"name,omitempty"`
+	NotificationRules []*NotificationRule `json:"notification_rules,omitempty"`
+	Role              string              `json:"role,omitempty"`
+	Self              string              `json:"self,omitempty"`
+	Summary           string              `json:"summary,omitempty"`
+	Teams             []*Team             `json:"teams,omitempty"`
+	TimeZone          string              `json:"time_zone,omitempty"`
+	Type              string              `json:"type,omitempty"`
+	User              *FullUser           `json:"user,omitempty"`
 }
 
 // ContactMethod represents a contact method for a user.
@@ -103,6 +126,14 @@ type ListUsersResponse struct {
 	Users  []*User `json:"users,omitempty"`
 }
 
+type ListFullUsersResponse struct {
+	Limit  int         `json:"limit,omitempty"`
+	More   bool        `json:"more,omitempty"`
+	Offset int         `json:"offset,omitempty"`
+	Total  int         `json:"total,omitempty"`
+	Users  []*FullUser `json:"users,omitempty"`
+}
+
 // GetUserOptions represents options when retrieving a user.
 type GetUserOptions struct {
 	Include []string `url:"include,omitempty,brackets"`
@@ -121,6 +152,27 @@ func (s *UserService) List(o *ListUsersOptions) (*ListUsersResponse, *Response, 
 	return v, resp, nil
 }
 
+func (s *UserService) ListAll(o *ListUsersOptions) ([]*FullUser, error) {
+	var users = make([]*FullUser, 0, 25)
+	var v *ListFullUsersResponse
+	more := true
+	offset := 0
+
+	for more {
+		log.Printf("==== Getting users at offset %d", offset)
+		v = new(ListFullUsersResponse)
+		_, err := s.client.newRequestDo("GET", "/users", o, nil, &v)
+		if err != nil {
+			return users, err
+		}
+		users = append(users, v.Users...)
+		more = v.More
+		offset += v.Limit
+		o.Offset = offset
+	}
+	return users, nil
+}
+
 // Create creates a new user.
 func (s *UserService) Create(user *User) (*User, *Response, error) {
 	u := "/users"
@@ -131,19 +183,52 @@ func (s *UserService) Create(user *User) (*User, *Response, error) {
 		return nil, nil, err
 	}
 
+	if err = cachePutUser(v.User); err != nil {
+		log.Printf("===== Error adding user %q to cache: %q", v.User.ID, err)
+	} else {
+		log.Printf("===== Added user %q to cache", v.User.ID)
+	}
+
 	return v.User, resp, nil
 }
 
 // Delete removes an existing user.
 func (s *UserService) Delete(id string) (*Response, error) {
 	u := fmt.Sprintf("/users/%s", id)
-	return s.client.newRequestDo("DELETE", u, nil, nil, nil)
+	resp, err := s.client.newRequestDo("DELETE", u, nil, nil, nil)
+
+	if cerr := cacheDeleteUser(id); cerr != nil {
+		log.Printf("===== Error deleting user %q from cache: %q", id, cerr)
+	} else {
+		log.Printf("===== Deleted user %q from cache", id)
+	}
+
+	return resp, err
 }
 
 // Get retrieves information about a user.
 func (s *UserService) Get(id string, o *GetUserOptions) (*User, *Response, error) {
 	u := fmt.Sprintf("/users/%s", id)
 	v := new(User)
+
+	if err := cacheGetUser(id, v); err == nil {
+		return v, nil, nil
+	}
+
+	resp, err := s.client.newRequestDo("GET", u, o, nil, v)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v.User, resp, nil
+}
+
+func (s *UserService) GetFull(id string) (*FullUser, *Response, error) {
+	u := fmt.Sprintf("/users/%s", id)
+	v := new(FullUser)
+	o := &GetUserOptions{
+		Include: []string{"contact_methods", "notification_rules"},
+	}
 
 	resp, err := s.client.newRequestDo("GET", u, o, nil, v)
 	if err != nil {
@@ -162,6 +247,8 @@ func (s *UserService) Update(id string, user *User) (*User, *Response, error) {
 	if err != nil {
 		return nil, nil, err
 	}
+
+	cachePutUser(v.User)
 
 	return v.User, resp, nil
 }
@@ -189,6 +276,12 @@ func (s *UserService) CreateContactMethod(userID string, contactMethod *ContactM
 		return nil, nil, err
 	}
 
+	if err = cachePutContactMethod(v.ContactMethod); err != nil {
+		log.Printf("===== Error adding contact method %q to cache: %q", v.ContactMethod.ID, err)
+	} else {
+		log.Printf("===== Added contact method %q to cache", v.ContactMethod.ID)
+	}
+
 	return v.ContactMethod, resp, nil
 }
 
@@ -196,6 +289,10 @@ func (s *UserService) CreateContactMethod(userID string, contactMethod *ContactM
 func (s *UserService) GetContactMethod(userID string, contactMethodID string) (*ContactMethod, *Response, error) {
 	u := fmt.Sprintf("/users/%s/contact_methods/%s", userID, contactMethodID)
 	v := new(ContactMethod)
+
+	if err := cacheGetContactMethod(contactMethodID, v); err == nil {
+		return v, nil, nil
+	}
 
 	resp, err := s.client.newRequestDo("GET", u, nil, nil, &v)
 	if err != nil {
@@ -215,13 +312,23 @@ func (s *UserService) UpdateContactMethod(userID, contactMethodID string, contac
 		return nil, nil, err
 	}
 
+	cachePutContactMethod(v.ContactMethod)
+
 	return v.ContactMethod, resp, nil
 }
 
 // DeleteContactMethod deletes a contact method for a user.
 func (s *UserService) DeleteContactMethod(userID, contactMethodID string) (*Response, error) {
 	u := fmt.Sprintf("/users/%s/contact_methods/%s", userID, contactMethodID)
-	return s.client.newRequestDo("DELETE", u, nil, nil, nil)
+	resp, err := s.client.newRequestDo("DELETE", u, nil, nil, nil)
+
+	if cerr := cacheDeleteContactMethod(contactMethodID); cerr != nil {
+		log.Printf("===== Error deleting contact method %q from cache: %q", contactMethodID, cerr)
+	} else {
+		log.Printf("===== Deleted contact method %q from cache", contactMethodID)
+	}
+
+	return resp, err
 }
 
 // CreateNotificationRule creates a new notification rule for a user.
@@ -234,6 +341,12 @@ func (s *UserService) CreateNotificationRule(userID string, rule *NotificationRu
 		return nil, nil, err
 	}
 
+	if err = cachePutNotificationRule(v.NotificationRule); err != nil {
+		log.Printf("===== Error adding notification rule %q to cache: %q", v.NotificationRule.ID, err)
+	} else {
+		log.Printf("===== Added notification rule %q to cache", v.NotificationRule.ID)
+	}
+
 	return v.NotificationRule, resp, nil
 }
 
@@ -241,6 +354,10 @@ func (s *UserService) CreateNotificationRule(userID string, rule *NotificationRu
 func (s *UserService) GetNotificationRule(userID string, ruleID string) (*NotificationRule, *Response, error) {
 	u := fmt.Sprintf("/users/%s/notification_rules/%s", userID, ruleID)
 	v := new(NotificationRule)
+
+	if err := cacheGetNotificationRule(ruleID, v); err == nil {
+		return v, nil, nil
+	}
 
 	resp, err := s.client.newRequestDo("GET", u, nil, nil, &v)
 	if err != nil {
@@ -260,11 +377,21 @@ func (s *UserService) UpdateNotificationRule(userID, ruleID string, rule *Notifi
 		return nil, nil, err
 	}
 
+	cachePutNotificationRule(v.NotificationRule)
+
 	return v.NotificationRule, resp, nil
 }
 
 // DeleteNotificationRule deletes a notification rule for a user.
 func (s *UserService) DeleteNotificationRule(userID, ruleID string) (*Response, error) {
 	u := fmt.Sprintf("/users/%s/notification_rules/%s", userID, ruleID)
-	return s.client.newRequestDo("DELETE", u, nil, nil, nil)
+	resp, err := s.client.newRequestDo("DELETE", u, nil, nil, nil)
+
+	if cerr := cacheDeleteNotificationRule(ruleID); cerr != nil {
+		log.Printf("===== Error deleting notification rule %q from cache: %q", ruleID, cerr)
+	} else {
+		log.Printf("===== Deleted notification rule %q from cache", ruleID)
+	}
+
+	return resp, err
 }

--- a/pagerduty/user.go
+++ b/pagerduty/user.go
@@ -45,6 +45,7 @@ type User struct {
 }
 
 // FullUser represents a user fetched with include[]=contact_methods,notification_rules.
+// This is only used when caching is enabled
 type FullUser struct {
 	AvatarURL         string              `json:"avatar_url,omitempty"`
 	Color             string              `json:"color,omitempty"`
@@ -126,6 +127,7 @@ type ListUsersResponse struct {
 	Users  []*User `json:"users,omitempty"`
 }
 
+// ListFullUsersResponse represents a list response containing FullUser objects.
 type ListFullUsersResponse struct {
 	Limit  int         `json:"limit,omitempty"`
 	More   bool        `json:"more,omitempty"`
@@ -152,6 +154,7 @@ func (s *UserService) List(o *ListUsersOptions) (*ListUsersResponse, *Response, 
 	return v, resp, nil
 }
 
+// ListAll lists users into FullUser objects
 func (s *UserService) ListAll(o *ListUsersOptions) ([]*FullUser, error) {
 	var users = make([]*FullUser, 0, 25)
 	var v *ListFullUsersResponse
@@ -223,6 +226,7 @@ func (s *UserService) Get(id string, o *GetUserOptions) (*User, *Response, error
 	return v.User, resp, nil
 }
 
+// GetFull retrieves information about a user including contact methods and notification rules.
 func (s *UserService) GetFull(id string) (*FullUser, *Response, error) {
 	u := fmt.Sprintf("/users/%s", id)
 	v := new(FullUser)


### PR DESCRIPTION
In environments with large configurations, terraform makes many, many requests to PagerDuty REST API. Some of these calls aren't necessary if the client fetches things a little differently and hangs on to the results for future use. This change adds basic caching of users, contact methods and notification rules to the client. You can choose to cache in memory or in MongoDB.

Caching is governed by the `TF_PAGERDUTY_CACHE` environment variable. Set it to a MongoDB URL (`mongodb://user:pass@host/db`) to cache in Mongo; set it to `memory` to cache in memory. If it's not set, then caching is turned off. If  you use MongoDB caching, you can optionally set `TF_PAGERDUTY_CACHE_MAX_AGE` to a duration (like `30s` or `15m`) to control the maximum age of the cache. The default max age is 10 seconds. When the cache is older than the max age, it's simply deleted and fully repopulated.

In testing with a configuration containing 100 users, 800 contact methods and 800 notification rules, terraform uses 3,502 HTTPS requests to create all 1,700 resources, and 1,704 requests to change one of those resources. With memory caching, creating all uses 1,802 requests and changing one uses 103 requests. With MongoDB caching, create all uses 1,704 requests and changing one uses 5 requests.