### PR TITLE
Add teams field to schedule

### DIFF
--- a/pagerduty/schedule.go
+++ b/pagerduty/schedule.go
@@ -33,6 +33,7 @@ type Schedule struct {
 	TimeZone             string                       `json:"time_zone,omitempty"`
 	Type                 string                       `json:"type,omitempty"`
 	Users                []*UserReference             `json:"users,omitempty"`
+	Teams                []*TeamReference             `json:"teams,omitempty"`
 }
 
 // SubSchedule represents a sub-schedule of a schedule.


### PR DESCRIPTION
Adding the `teams` field to the `Schedule` struct. Resolves #49.