### PR TITLE
Run tests with Github Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+name: test
+on: [push]
+
+env:
+  GO111MODULE: off
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
+      - run: make tools
+      - run: make test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          path: src/github.com/heimweh/go-pagerduty/
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
           go-version: 1.16
-      - run: make tools
-      - run: make test
+      - run: |
+          export GOPATH=${GITHUB_WORKSPACE}
+          cd ${GITHUB_WORKSPACE}/src/github.com/heimweh/go-pagerduty/
+          make tools
+          make test


### PR DESCRIPTION
This PR adds support for running tests with Github Actions as the [Travis CI](https://app.travis-ci.com/github/heimweh/go-pagerduty/) job does not seem to be enabled.