### PR TITLE
pagerduty: cleanup of remaining structs

### DIFF
--- a/pagerduty/addon.go
+++ b/pagerduty/addon.go
@@ -8,7 +8,6 @@ type AddonService service
 
 // Addon represents a PagerDuty add-on.
 type Addon struct {
-	Addon   *Addon `json:"addon,omitempty"`
 	HTMLURL string `json:"html_url,omitempty"`
 	ID      string `json:"id,omitempty"`
 	Name    string `json:"name,omitempty"`
@@ -38,6 +37,11 @@ type ListAddonsResponse struct {
 	Addons []*Addon `json:"addons,omitempty"`
 }
 
+// AddonPayload represents an addon.
+type AddonPayload struct {
+	Addon *Addon `json:"addon,omitempty"`
+}
+
 // List lists installed add-ons.
 func (s *AddonService) List(o *ListAddonsOptions) (*ListAddonsResponse, *Response, error) {
 	u := "/addons"
@@ -54,9 +58,9 @@ func (s *AddonService) List(o *ListAddonsOptions) (*ListAddonsResponse, *Respons
 // Install installs an add-on.
 func (s *AddonService) Install(addon *Addon) (*Addon, *Response, error) {
 	u := "/addons"
-	v := new(Addon)
+	v := new(AddonPayload)
 
-	resp, err := s.client.newRequestDo("POST", u, nil, &Addon{Addon: addon}, v)
+	resp, err := s.client.newRequestDo("POST", u, nil, &AddonPayload{Addon: addon}, v)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -73,7 +77,7 @@ func (s *AddonService) Delete(id string) (*Response, error) {
 // Get retrieves information about an add-on.
 func (s *AddonService) Get(id string) (*Addon, *Response, error) {
 	u := fmt.Sprintf("/addons/%s", id)
-	v := new(Addon)
+	v := new(AddonPayload)
 
 	resp, err := s.client.newRequestDo("GET", u, nil, nil, &v)
 	if err != nil {
@@ -86,8 +90,8 @@ func (s *AddonService) Get(id string) (*Addon, *Response, error) {
 // Update updates an existing add-on.
 func (s *AddonService) Update(id string, addon *Addon) (*Addon, *Response, error) {
 	u := fmt.Sprintf("/addons/%s", id)
-	v := new(Addon)
-	resp, err := s.client.newRequestDo("PUT", u, nil, &Addon{Addon: addon}, &v)
+	v := new(AddonPayload)
+	resp, err := s.client.newRequestDo("PUT", u, nil, &AddonPayload{Addon: addon}, &v)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pagerduty/addon_test.go
+++ b/pagerduty/addon_test.go
@@ -45,7 +45,7 @@ func TestAddonsInstall(t *testing.T) {
 	mux.HandleFunc("/addons", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
 		w.WriteHeader(http.StatusCreated)
-		v := new(Addon)
+		v := new(AddonPayload)
 		json.NewDecoder(r.Body).Decode(v)
 		if !reflect.DeepEqual(v.Addon, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
@@ -102,7 +102,7 @@ func TestAddonsUpdate(t *testing.T) {
 
 	mux.HandleFunc("/addons/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
-		v := new(Addon)
+		v := new(AddonPayload)
 		json.NewDecoder(r.Body).Decode(v)
 		if !reflect.DeepEqual(v.Addon, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)

--- a/pagerduty/escalation_policy.go
+++ b/pagerduty/escalation_policy.go
@@ -15,19 +15,18 @@ type EscalationRule struct {
 
 // EscalationPolicy represents an escalation policy.
 type EscalationPolicy struct {
-	Description      string              `json:"description,omitempty"`
-	EscalationPolicy *EscalationPolicy   `json:"escalation_policy,omitempty"`
-	EscalationRules  []*EscalationRule   `json:"escalation_rules,omitempty"`
-	HTMLURL          string              `json:"html_url,omitempty"`
-	ID               string              `json:"id,omitempty"`
-	Name             string              `json:"name,omitempty"`
-	NumLoops         *int                `json:"num_loops,omitempty"`
-	RepeatEnabled    bool                `json:"repeat_enabled,omitempty"`
-	Self             string              `json:"self,omitempty"`
-	Services         []*ServiceReference `json:"services,omitempty"`
-	Summary          string              `json:"summary,omitempty"`
-	Teams            []*TeamReference    `json:"teams"`
-	Type             string              `json:"type,omitempty"`
+	Description     string              `json:"description,omitempty"`
+	EscalationRules []*EscalationRule   `json:"escalation_rules,omitempty"`
+	HTMLURL         string              `json:"html_url,omitempty"`
+	ID              string              `json:"id,omitempty"`
+	Name            string              `json:"name,omitempty"`
+	NumLoops        *int                `json:"num_loops,omitempty"`
+	RepeatEnabled   bool                `json:"repeat_enabled,omitempty"`
+	Self            string              `json:"self,omitempty"`
+	Services        []*ServiceReference `json:"services,omitempty"`
+	Summary         string              `json:"summary,omitempty"`
+	Teams           []*TeamReference    `json:"teams"`
+	Type            string              `json:"type,omitempty"`
 }
 
 // ListEscalationPoliciesResponse represents a list response of escalation policies.
@@ -84,12 +83,17 @@ func (s *EscalationPolicyService) List(o *ListEscalationPoliciesOptions) (*ListE
 	return v, resp, nil
 }
 
+// EscalationPolicyPayload represents an escalation policy.
+type EscalationPolicyPayload struct {
+	EscalationPolicy *EscalationPolicy `json:"escalation_policy"`
+}
+
 // Create creates a new escalation policy.
 func (s *EscalationPolicyService) Create(escalationPolicy *EscalationPolicy) (*EscalationPolicy, *Response, error) {
 	u := "/escalation_policies"
-	v := new(EscalationPolicy)
+	v := new(EscalationPolicyPayload)
 
-	resp, err := s.client.newRequestDo("POST", u, nil, &EscalationPolicy{EscalationPolicy: escalationPolicy}, v)
+	resp, err := s.client.newRequestDo("POST", u, nil, &EscalationPolicyPayload{EscalationPolicy: escalationPolicy}, v)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -106,7 +110,7 @@ func (s *EscalationPolicyService) Delete(id string) (*Response, error) {
 // Get retrieves information about an escalation policy.
 func (s *EscalationPolicyService) Get(id string, o *GetEscalationPolicyOptions) (*EscalationPolicy, *Response, error) {
 	u := fmt.Sprintf("/escalation_policies/%s", id)
-	v := new(EscalationPolicy)
+	v := new(EscalationPolicyPayload)
 
 	resp, err := s.client.newRequestDo("GET", u, o, nil, v)
 	if err != nil {
@@ -119,9 +123,9 @@ func (s *EscalationPolicyService) Get(id string, o *GetEscalationPolicyOptions) 
 // Update updates an existing escalation policy.
 func (s *EscalationPolicyService) Update(id string, escalationPolicy *EscalationPolicy) (*EscalationPolicy, *Response, error) {
 	u := fmt.Sprintf("/escalation_policies/%s", id)
-	v := new(EscalationPolicy)
+	v := new(EscalationPolicyPayload)
 
-	resp, err := s.client.newRequestDo("PUT", u, nil, &EscalationPolicy{EscalationPolicy: escalationPolicy}, v)
+	resp, err := s.client.newRequestDo("PUT", u, nil, &EscalationPolicyPayload{EscalationPolicy: escalationPolicy}, v)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pagerduty/escalation_policy_test.go
+++ b/pagerduty/escalation_policy_test.go
@@ -42,7 +42,7 @@ func TestEscalationPoliciesCreate(t *testing.T) {
 
 	mux.HandleFunc("/escalation_policies", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		v := new(EscalationPolicy)
+		v := new(EscalationPolicyPayload)
 		json.NewDecoder(r.Body).Decode(v)
 		if !reflect.DeepEqual(v.EscalationPolicy, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
@@ -142,7 +142,7 @@ func TestEscalationPoliciesUpdateTeams(t *testing.T) {
 
 	mux.HandleFunc("/escalation_policies/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
-		v := new(EscalationPolicy)
+		v := new(EscalationPolicyPayload)
 		json.NewDecoder(r.Body).Decode(v)
 		if !reflect.DeepEqual(v.EscalationPolicy, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)

--- a/pagerduty/extension.go
+++ b/pagerduty/extension.go
@@ -8,7 +8,6 @@ type ExtensionService service
 
 // Extension represents an extension.
 type Extension struct {
-	Extension        *Extension                `json:"extension,omitempty"`
 	ID               string                    `json:"id,omitempty"`
 	Summary          string                    `json:"summary,omitempty"`
 	Type             string                    `json:"type,omitempty"`
@@ -38,6 +37,11 @@ type ListExtensionsResponse struct {
 	Total      int          `json:"total,omitempty"`
 }
 
+// ExtensionPayload represents an extension.
+type ExtensionPayload struct {
+	Extension *Extension `json:"extension"`
+}
+
 // List lists existing extensions.
 func (s *ExtensionService) List(o *ListExtensionsOptions) (*ListExtensionsResponse, *Response, error) {
 	u := "/extensions"
@@ -54,9 +58,9 @@ func (s *ExtensionService) List(o *ListExtensionsOptions) (*ListExtensionsRespon
 // Create creates a new extension.
 func (s *ExtensionService) Create(extension *Extension) (*Extension, *Response, error) {
 	u := "/extensions"
-	v := new(Extension)
+	v := new(ExtensionPayload)
 
-	resp, err := s.client.newRequestDo("POST", u, nil, &Extension{Extension: extension}, v)
+	resp, err := s.client.newRequestDo("POST", u, nil, &ExtensionPayload{Extension: extension}, v)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -73,7 +77,7 @@ func (s *ExtensionService) Delete(id string) (*Response, error) {
 // Get retrieves information about an extension.
 func (s *ExtensionService) Get(id string) (*Extension, *Response, error) {
 	u := fmt.Sprintf("/extensions/%s", id)
-	v := new(Extension)
+	v := new(ExtensionPayload)
 
 	resp, err := s.client.newRequestDo("GET", u, nil, nil, &v)
 	if err != nil {
@@ -86,8 +90,8 @@ func (s *ExtensionService) Get(id string) (*Extension, *Response, error) {
 // Update updates an existing extension.
 func (s *ExtensionService) Update(id string, extension *Extension) (*Extension, *Response, error) {
 	u := fmt.Sprintf("/extensions/%s", id)
-	v := new(Extension)
-	resp, err := s.client.newRequestDo("PUT", u, nil, &Extension{Extension: extension}, &v)
+	v := new(ExtensionPayload)
+	resp, err := s.client.newRequestDo("PUT", u, nil, &ExtensionPayload{Extension: extension}, &v)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pagerduty/extension_schema.go
+++ b/pagerduty/extension_schema.go
@@ -8,20 +8,19 @@ type ExtensionSchemaService service
 
 // ExtensionSchema represents an extension schema.
 type ExtensionSchema struct {
-	ExtensionSchema *ExtensionSchema `json:"extension_schema,omitempty"`
-	Description     string           `json:"description,omitempty"`
-	GuideURL        string           `json:"guide_url,omitempty"`
-	HTMLURL         string           `json:"html_url,omitempty"`
-	IconURL         string           `json:"icon_url,omitempty"`
-	ID              string           `json:"id,omitempty"`
-	Key             string           `json:"key,omitempty"`
-	Label           string           `json:"label,omitempty"`
-	LogoURL         string           `json:"logo_url,omitempty"`
-	Self            string           `json:"self,omitempty"`
-	SendTypes       []string         `json:"send_types,omitempty"`
-	Summary         string           `json:"summary,omitempty"`
-	Type            string           `json:"type,omitempty"`
-	URL             string           `json:"url,omitempty"`
+	Description string   `json:"description,omitempty"`
+	GuideURL    string   `json:"guide_url,omitempty"`
+	HTMLURL     string   `json:"html_url,omitempty"`
+	IconURL     string   `json:"icon_url,omitempty"`
+	ID          string   `json:"id,omitempty"`
+	Key         string   `json:"key,omitempty"`
+	Label       string   `json:"label,omitempty"`
+	LogoURL     string   `json:"logo_url,omitempty"`
+	Self        string   `json:"self,omitempty"`
+	SendTypes   []string `json:"send_types,omitempty"`
+	Summary     string   `json:"summary,omitempty"`
+	Type        string   `json:"type,omitempty"`
+	URL         string   `json:"url,omitempty"`
 }
 
 // ListExtensionSchemasResponse represents a list response of extension schemas.
@@ -41,6 +40,11 @@ type ListExtensionSchemasOptions struct {
 	Query  string `url:"query,omitempty"`
 }
 
+// ExtensionSchemaPayload represents an extension schema.
+type ExtensionSchemaPayload struct {
+	ExtensionSchema *ExtensionSchema `json:"extension_schema"`
+}
+
 // List lists extension schemas.
 func (s *ExtensionSchemaService) List(o *ListExtensionSchemasOptions) (*ListExtensionSchemasResponse, *Response, error) {
 	u := "/extension_schemas"
@@ -57,7 +61,7 @@ func (s *ExtensionSchemaService) List(o *ListExtensionSchemasOptions) (*ListExte
 // Get retrieves information about an extension schema.
 func (s *ExtensionSchemaService) Get(id string) (*ExtensionSchema, *Response, error) {
 	u := fmt.Sprintf("/extension_schemas/%s", id)
-	v := new(ExtensionSchema)
+	v := new(ExtensionSchemaPayload)
 
 	resp, err := s.client.newRequestDo("GET", u, nil, nil, &v)
 	if err != nil {

--- a/pagerduty/extension_test.go
+++ b/pagerduty/extension_test.go
@@ -42,7 +42,7 @@ func TestExtensionsCreate(t *testing.T) {
 
 	mux.HandleFunc("/extensions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		v := new(Extension)
+		v := new(ExtensionPayload)
 		json.NewDecoder(r.Body).Decode(v)
 		if !reflect.DeepEqual(v.Extension, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)

--- a/pagerduty/maintenance_window.go
+++ b/pagerduty/maintenance_window.go
@@ -8,20 +8,19 @@ type MaintenanceWindowService service
 
 // MaintenanceWindow represents a PagerDuty maintenance window.
 type MaintenanceWindow struct {
-	CreatedBy         *UserReference      `json:"created_by,omitempty"`
-	Description       string              `json:"description,omitempty"`
-	EndTime           string              `json:"end_time,omitempty"`
-	HTMLURL           string              `json:"html_url,omitempty"`
-	ID                string              `json:"id,omitempty"`
-	MaintenanceWindow *MaintenanceWindow  `json:"maintenance_window,omitempty"`
-	Self              string              `json:"self,omitempty"`
-	SequenceNumber    int                 `json:"sequence_number,omitempty"`
-	Services          []*ServiceReference `json:"services,omitempty"`
-	Src               string              `json:"src,omitempty"`
-	StartTime         string              `json:"start_time,omitempty"`
-	Summary           string              `json:"summary,omitempty"`
-	Teams             []*TeamReference    `json:"teams,omitempty"`
-	Type              string              `json:"type,omitempty"`
+	CreatedBy      *UserReference      `json:"created_by,omitempty"`
+	Description    string              `json:"description,omitempty"`
+	EndTime        string              `json:"end_time,omitempty"`
+	HTMLURL        string              `json:"html_url,omitempty"`
+	ID             string              `json:"id,omitempty"`
+	Self           string              `json:"self,omitempty"`
+	SequenceNumber int                 `json:"sequence_number,omitempty"`
+	Services       []*ServiceReference `json:"services,omitempty"`
+	Src            string              `json:"src,omitempty"`
+	StartTime      string              `json:"start_time,omitempty"`
+	Summary        string              `json:"summary,omitempty"`
+	Teams          []*TeamReference    `json:"teams,omitempty"`
+	Type           string              `json:"type,omitempty"`
 }
 
 // ListMaintenanceWindowsOptions represents options when listing maintenance windows.
@@ -42,6 +41,11 @@ type ListMaintenanceWindowsResponse struct {
 	Total              int                  `json:"total,omitempty"`
 }
 
+// MaintenanceWindowPayload represents a maintenance window.
+type MaintenanceWindowPayload struct {
+	MaintenanceWindow *MaintenanceWindow `json:"maintenance_window,omitempty"`
+}
+
 // List lists existing maintenance windows.
 func (s *MaintenanceWindowService) List(o *ListMaintenanceWindowsOptions) (*ListMaintenanceWindowsResponse, *Response, error) {
 	u := "/maintenance_windows"
@@ -58,9 +62,9 @@ func (s *MaintenanceWindowService) List(o *ListMaintenanceWindowsOptions) (*List
 // Create creates a new maintenancce window.
 func (s *MaintenanceWindowService) Create(maintenanceWindow *MaintenanceWindow) (*MaintenanceWindow, *Response, error) {
 	u := "/maintenance_windows"
-	v := new(MaintenanceWindow)
+	v := new(MaintenanceWindowPayload)
 
-	resp, err := s.client.newRequestDo("POST", u, nil, &MaintenanceWindow{MaintenanceWindow: maintenanceWindow}, v)
+	resp, err := s.client.newRequestDo("POST", u, nil, &MaintenanceWindowPayload{MaintenanceWindow: maintenanceWindow}, v)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -77,7 +81,7 @@ func (s *MaintenanceWindowService) Delete(id string) (*Response, error) {
 // Get retrieves information about a maintenance window.
 func (s *MaintenanceWindowService) Get(id string) (*MaintenanceWindow, *Response, error) {
 	u := fmt.Sprintf("/maintenance_windows/%s", id)
-	v := new(MaintenanceWindow)
+	v := new(MaintenanceWindowPayload)
 
 	resp, err := s.client.newRequestDo("GET", u, nil, nil, &v)
 	if err != nil {
@@ -90,8 +94,8 @@ func (s *MaintenanceWindowService) Get(id string) (*MaintenanceWindow, *Response
 // Update updates an existing maintenance window.
 func (s *MaintenanceWindowService) Update(id string, maintenanceWindow *MaintenanceWindow) (*MaintenanceWindow, *Response, error) {
 	u := fmt.Sprintf("/maintenance_windows/%s", id)
-	v := new(MaintenanceWindow)
-	resp, err := s.client.newRequestDo("PUT", u, nil, &MaintenanceWindow{MaintenanceWindow: maintenanceWindow}, &v)
+	v := new(MaintenanceWindowPayload)
+	resp, err := s.client.newRequestDo("PUT", u, nil, &MaintenanceWindowPayload{MaintenanceWindow: maintenanceWindow}, &v)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pagerduty/maintenance_window_test.go
+++ b/pagerduty/maintenance_window_test.go
@@ -42,7 +42,7 @@ func TestMaintenanceWindowsCreate(t *testing.T) {
 
 	mux.HandleFunc("/maintenance_windows", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		v := new(MaintenanceWindow)
+		v := new(MaintenanceWindowPayload)
 		json.NewDecoder(r.Body).Decode(v)
 		if !reflect.DeepEqual(v.MaintenanceWindow, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)

--- a/pagerduty/schedule.go
+++ b/pagerduty/schedule.go
@@ -10,11 +10,10 @@ type ScheduleService service
 
 // Override represents an override
 type Override struct {
-	Override *Override      `json:"override,omitempty"`
-	ID       string         `json:"id,omitempty"`
-	Start    string         `json:"start,omitempty"`
-	End      string         `json:"end,omitempty"`
-	User     *UserReference `json:"user,omitempty"`
+	ID    string         `json:"id,omitempty"`
+	Start string         `json:"start,omitempty"`
+	End   string         `json:"end,omitempty"`
+	User  *UserReference `json:"user,omitempty"`
 }
 
 // Schedule represents a schedule.
@@ -26,7 +25,6 @@ type Schedule struct {
 	ID                   string                       `json:"id,omitempty"`
 	Name                 string                       `json:"name,omitempty"`
 	OverridesSubSchedule *SubSchedule                 `json:"overrides_subschedule,omitempty"`
-	Schedule             *Schedule                    `json:"schedule,omitempty"`
 	ScheduleLayers       []*ScheduleLayer             `json:"schedule_layers,omitempty"`
 	Self                 string                       `json:"self,omitempty"`
 	Summary              string                       `json:"summary,omitempty"`
@@ -137,6 +135,16 @@ type UpdateScheduleOptions struct {
 	Overflow bool `url:"overflow,omitempty"`
 }
 
+// SchedulePayload represents a schedule.
+type SchedulePayload struct {
+	Schedule *Schedule `json:"schedule,omitempty"`
+}
+
+// OverridePayload represents an override.
+type OverridePayload struct {
+	Override *Override `json:"override,omitempty"`
+}
+
 // List lists existing schedules.
 func (s *ScheduleService) List(o *ListSchedulesOptions) (*ListSchedulesResponse, *Response, error) {
 	u := "/schedules"
@@ -153,9 +161,9 @@ func (s *ScheduleService) List(o *ListSchedulesOptions) (*ListSchedulesResponse,
 // Create creates a new schedule.
 func (s *ScheduleService) Create(schedule *Schedule, o *CreateScheduleOptions) (*Schedule, *Response, error) {
 	u := "/schedules"
-	v := new(Schedule)
+	v := new(SchedulePayload)
 
-	resp, err := s.client.newRequestDo("POST", u, o, &Schedule{Schedule: schedule}, &v)
+	resp, err := s.client.newRequestDo("POST", u, o, &SchedulePayload{Schedule: schedule}, &v)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -172,7 +180,7 @@ func (s *ScheduleService) Delete(id string) (*Response, error) {
 // Get retrieves information about a schedule.
 func (s *ScheduleService) Get(id string, o *GetScheduleOptions) (*Schedule, *Response, error) {
 	u := fmt.Sprintf("/schedules/%s", id)
-	v := new(Schedule)
+	v := new(SchedulePayload)
 
 	resp, err := s.client.newRequestDo("GET", u, o, nil, &v)
 	if err != nil {
@@ -185,9 +193,9 @@ func (s *ScheduleService) Get(id string, o *GetScheduleOptions) (*Schedule, *Res
 // Update updates an existing schedule.
 func (s *ScheduleService) Update(id string, schedule *Schedule, o *UpdateScheduleOptions) (*Schedule, *Response, error) {
 	u := fmt.Sprintf("/schedules/%s", id)
-	v := new(Schedule)
+	v := new(SchedulePayload)
 
-	resp, err := s.client.newRequestDo("PUT", u, o, &Schedule{Schedule: schedule}, &v)
+	resp, err := s.client.newRequestDo("PUT", u, o, &SchedulePayload{Schedule: schedule}, &v)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -224,9 +232,9 @@ func (s *ScheduleService) ListOverrides(scheduleID string, o *ListOverridesOptio
 // CreateOverride creates an override for a specific user covering the specified time range.
 func (s *ScheduleService) CreateOverride(id string, override *Override) (*Override, *Response, error) {
 	u := fmt.Sprintf("/schedules/%s/overrides", id)
-	v := new(Override)
+	v := new(OverridePayload)
 
-	resp, err := s.client.newRequestDo("POST", u, nil, &Override{Override: override}, &v)
+	resp, err := s.client.newRequestDo("POST", u, nil, &OverridePayload{Override: override}, &v)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pagerduty/schedule_test.go
+++ b/pagerduty/schedule_test.go
@@ -44,7 +44,7 @@ func TestSchedulesCreate(t *testing.T) {
 
 	mux.HandleFunc("/schedules", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		v := new(Schedule)
+		v := new(SchedulePayload)
 		json.NewDecoder(r.Body).Decode(v)
 		if !reflect.DeepEqual(v.Schedule, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
@@ -114,7 +114,7 @@ func TestSchedulesUpdate(t *testing.T) {
 
 	mux.HandleFunc("/schedules/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
-		v := new(Schedule)
+		v := new(SchedulePayload)
 		json.NewDecoder(r.Body).Decode(v)
 		if !reflect.DeepEqual(v.Schedule, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)

--- a/pagerduty/service.go
+++ b/pagerduty/service.go
@@ -60,7 +60,6 @@ type Integration struct {
 	CreatedAt        string            `json:"created_at,omitempty"`
 	HTMLURL          string            `json:"html_url,omitempty"`
 	ID               string            `json:"id,omitempty"`
-	Integration      *Integration      `json:"integration,omitempty"`
 	IntegrationEmail string            `json:"integration_email,omitempty"`
 	IntegrationKey   string            `json:"integration_key,omitempty"`
 	Name             string            `json:"name,omitempty"`
@@ -114,6 +113,11 @@ type ServiceEventRule struct {
 	Position   *int              `json:"position,omitempty"`
 	Actions    *RuleActions      `json:"actions,omitempty"`
 	Service    *ServiceReference `json:"service_id,omitempty"`
+}
+
+// IntegrationPayload represents an integration.
+type IntegrationPayload struct {
+	Integration *Integration `json:"integration,omitempty"`
 }
 
 // ServiceEventRulePayload represents a payload for service event rules
@@ -231,9 +235,9 @@ func (s *ServicesService) Update(id string, service *Service) (*Service, *Respon
 // CreateIntegration creates a new service integration.
 func (s *ServicesService) CreateIntegration(serviceID string, integration *Integration) (*Integration, *Response, error) {
 	u := fmt.Sprintf("/services/%s/integrations", serviceID)
-	v := new(Integration)
+	v := new(IntegrationPayload)
 
-	resp, err := s.client.newRequestDo("POST", u, nil, &Integration{Integration: integration}, &v)
+	resp, err := s.client.newRequestDo("POST", u, nil, &IntegrationPayload{Integration: integration}, &v)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -244,7 +248,7 @@ func (s *ServicesService) CreateIntegration(serviceID string, integration *Integ
 // GetIntegration retrieves information about a service integration.
 func (s *ServicesService) GetIntegration(serviceID, integrationID string, o *GetIntegrationOptions) (*Integration, *Response, error) {
 	u := fmt.Sprintf("/services/%s/integrations/%s", serviceID, integrationID)
-	v := new(Integration)
+	v := new(IntegrationPayload)
 
 	resp, err := s.client.newRequestDo("GET", u, o, nil, &v)
 	if err != nil {
@@ -257,9 +261,9 @@ func (s *ServicesService) GetIntegration(serviceID, integrationID string, o *Get
 // UpdateIntegration updates an existing service integration.
 func (s *ServicesService) UpdateIntegration(serviceID, integrationID string, integration *Integration) (*Integration, *Response, error) {
 	u := fmt.Sprintf("/services/%s/integrations/%s", serviceID, integrationID)
-	v := new(Integration)
+	v := new(IntegrationPayload)
 
-	resp, err := s.client.newRequestDo("PUT", u, nil, &Integration{Integration: integration}, &v)
+	resp, err := s.client.newRequestDo("PUT", u, nil, &IntegrationPayload{Integration: integration}, &v)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pagerduty/service_test.go
+++ b/pagerduty/service_test.go
@@ -140,7 +140,7 @@ func TestServicesCreateIntegration(t *testing.T) {
 
 	mux.HandleFunc("/services/1/integrations", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		v := new(Integration)
+		v := new(IntegrationPayload)
 		json.NewDecoder(r.Body).Decode(v)
 		if !reflect.DeepEqual(v.Integration, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
@@ -173,7 +173,7 @@ func TestServicesUpdateIntegration(t *testing.T) {
 
 	mux.HandleFunc("/services/1/integrations/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
-		v := new(Integration)
+		v := new(IntegrationPayload)
 		json.NewDecoder(r.Body).Decode(v)
 		if !reflect.DeepEqual(v.Integration, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)

--- a/pagerduty/team.go
+++ b/pagerduty/team.go
@@ -14,7 +14,6 @@ type Team struct {
 	Name        string         `json:"name,omitempty"`
 	Self        string         `json:"self,omitempty"`
 	Summary     string         `json:"summary,omitempty"`
-	Team        *Team          `json:"team,omitempty"`
 	Type        string         `json:"type,omitempty"`
 	Parent      *TeamReference `json:"parent,omitempty"`
 }
@@ -65,6 +64,11 @@ type teamRole struct {
 	Role string `json:"role,omitempty"`
 }
 
+// TeamPayload represents a team.
+type TeamPayload struct {
+	Team *Team `json:"team,omitempty"`
+}
+
 // List lists existing teams.
 func (s *TeamService) List(o *ListTeamsOptions) (*ListTeamsResponse, *Response, error) {
 	u := "/teams"
@@ -81,9 +85,9 @@ func (s *TeamService) List(o *ListTeamsOptions) (*ListTeamsResponse, *Response, 
 // Create creates a new team.
 func (s *TeamService) Create(team *Team) (*Team, *Response, error) {
 	u := "/teams"
-	v := new(Team)
+	v := new(TeamPayload)
 
-	resp, err := s.client.newRequestDo("POST", u, nil, &Team{Team: team}, &v)
+	resp, err := s.client.newRequestDo("POST", u, nil, &TeamPayload{Team: team}, &v)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -100,7 +104,7 @@ func (s *TeamService) Delete(id string) (*Response, error) {
 // Get retrieves information about a team.
 func (s *TeamService) Get(id string) (*Team, *Response, error) {
 	u := fmt.Sprintf("/teams/%s", id)
-	v := new(Team)
+	v := new(TeamPayload)
 
 	resp, err := s.client.newRequestDo("GET", u, nil, nil, &v)
 	if err != nil {
@@ -113,9 +117,9 @@ func (s *TeamService) Get(id string) (*Team, *Response, error) {
 // Update updates an existing team.
 func (s *TeamService) Update(id string, team *Team) (*Team, *Response, error) {
 	u := fmt.Sprintf("/teams/%s", id)
-	v := new(Team)
+	v := new(TeamPayload)
 
-	resp, err := s.client.newRequestDo("PUT", u, nil, &Team{Team: team}, &v)
+	resp, err := s.client.newRequestDo("PUT", u, nil, &TeamPayload{Team: team}, &v)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pagerduty/team_test.go
+++ b/pagerduty/team_test.go
@@ -44,7 +44,7 @@ func TestTeamsCreate(t *testing.T) {
 
 	mux.HandleFunc("/teams", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		v := new(Team)
+		v := new(TeamPayload)
 		json.NewDecoder(r.Body).Decode(v)
 		if !reflect.DeepEqual(v.Team, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
@@ -81,7 +81,7 @@ func TestTeamsCreateWithParent(t *testing.T) {
 
 	mux.HandleFunc("/teams", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		v := new(Team)
+		v := new(TeamPayload)
 		json.NewDecoder(r.Body).Decode(v)
 		if !reflect.DeepEqual(v.Team, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
@@ -155,7 +155,7 @@ func TestTeamsUpdate(t *testing.T) {
 
 	mux.HandleFunc("/teams/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
-		v := new(Team)
+		v := new(TeamPayload)
 		json.NewDecoder(r.Body).Decode(v)
 		if !reflect.DeepEqual(v.Team, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)

--- a/pagerduty/user.go
+++ b/pagerduty/user.go
@@ -11,7 +11,6 @@ type UserService service
 
 // NotificationRule represents a user notification rule.
 type NotificationRule struct {
-	NotificationRule    *NotificationRule       `json:"notification_rule,omitempty"`
 	ContactMethod       *ContactMethodReference `json:"contact_method,omitempty"`
 	HTMLURL             string                  `json:"html_url,omitempty"`
 	ID                  string                  `json:"id,omitempty"`
@@ -20,6 +19,11 @@ type NotificationRule struct {
 	Summary             string                  `json:"summary,omitempty"`
 	Type                string                  `json:"type,omitempty"`
 	Urgency             string                  `json:"urgency,omitempty"`
+}
+
+// NotificationRulePayload represents a notification rule.
+type NotificationRulePayload struct {
+	NotificationRule *NotificationRule `json:"notification_rule,omitempty"`
 }
 
 // User represents a user.
@@ -41,7 +45,11 @@ type User struct {
 	Teams             []*TeamReference          `json:"teams,omitempty"`
 	TimeZone          string                    `json:"time_zone,omitempty"`
 	Type              string                    `json:"type,omitempty"`
-	User              *User                     `json:"user,omitempty"`
+}
+
+// UserPayload represents a user.
+type UserPayload struct {
+	User *User `json:"user,omitempty"`
 }
 
 // FullUser represents a user fetched with include[]=contact_methods,notification_rules.
@@ -64,20 +72,23 @@ type FullUser struct {
 	Teams             []*Team             `json:"teams,omitempty"`
 	TimeZone          string              `json:"time_zone,omitempty"`
 	Type              string              `json:"type,omitempty"`
-	User              *FullUser           `json:"user,omitempty"`
+}
+
+// FullUserPayload represents a user.
+type FullUserPayload struct {
+	User *FullUser `json:"user,omitempty"`
 }
 
 // ContactMethod represents a contact method for a user.
 type ContactMethod struct {
-	ContactMethod *ContactMethod `json:"contact_method,omitempty"`
-	ID            string         `json:"id,omitempty"`
-	Summary       string         `json:"summary,omitempty"`
-	Type          string         `json:"type,omitempty"`
-	Self          string         `json:"self,omitempty"`
-	HTMLURL       string         `json:"html_url,omitempty"`
-	Label         string         `json:"label,omitempty"`
-	Address       string         `json:"address,omitempty"`
-	BlackListed   bool           `json:"blacklisted,omitempty"`
+	ID          string `json:"id,omitempty"`
+	Summary     string `json:"summary,omitempty"`
+	Type        string `json:"type,omitempty"`
+	Self        string `json:"self,omitempty"`
+	HTMLURL     string `json:"html_url,omitempty"`
+	Label       string `json:"label,omitempty"`
+	Address     string `json:"address,omitempty"`
+	BlackListed bool   `json:"blacklisted,omitempty"`
 
 	// Email contact method options
 	SendShortEmail bool `json:"send_short_email,omitempty"`
@@ -90,6 +101,11 @@ type ContactMethod struct {
 	DeviceType string                    `json:"device_type,omitempty"`
 	Sounds     []*PushContactMethodSound `json:"sounds,omitempty"`
 	CreatedAt  string                    `json:"created_at,omitempty"`
+}
+
+// ContactMethodPayload represents a contact method.
+type ContactMethodPayload struct {
+	ContactMethod *ContactMethod `json:"contact_method"`
 }
 
 // PushContactMethodSound represents a sound for a push contact method.
@@ -179,9 +195,9 @@ func (s *UserService) ListAll(o *ListUsersOptions) ([]*FullUser, error) {
 // Create creates a new user.
 func (s *UserService) Create(user *User) (*User, *Response, error) {
 	u := "/users"
-	v := new(User)
+	v := new(UserPayload)
 
-	resp, err := s.client.newRequestDo("POST", u, nil, &User{User: user}, &v)
+	resp, err := s.client.newRequestDo("POST", u, nil, &UserPayload{User: user}, &v)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -212,10 +228,10 @@ func (s *UserService) Delete(id string) (*Response, error) {
 // Get retrieves information about a user.
 func (s *UserService) Get(id string, o *GetUserOptions) (*User, *Response, error) {
 	u := fmt.Sprintf("/users/%s", id)
-	v := new(User)
+	v := new(UserPayload)
 
 	if err := cacheGetUser(id, v); err == nil {
-		return v, nil, nil
+		return v.User, nil, nil
 	}
 
 	resp, err := s.client.newRequestDo("GET", u, o, nil, v)
@@ -229,7 +245,7 @@ func (s *UserService) Get(id string, o *GetUserOptions) (*User, *Response, error
 // GetFull retrieves information about a user including contact methods and notification rules.
 func (s *UserService) GetFull(id string) (*FullUser, *Response, error) {
 	u := fmt.Sprintf("/users/%s", id)
-	v := new(FullUser)
+	v := new(FullUserPayload)
 	o := &GetUserOptions{
 		Include: []string{"contact_methods", "notification_rules"},
 	}
@@ -245,9 +261,9 @@ func (s *UserService) GetFull(id string) (*FullUser, *Response, error) {
 // Update updates an existing user.
 func (s *UserService) Update(id string, user *User) (*User, *Response, error) {
 	u := fmt.Sprintf("/users/%s", id)
-	v := new(User)
+	v := new(UserPayload)
 
-	resp, err := s.client.newRequestDo("PUT", u, nil, &User{User: user}, &v)
+	resp, err := s.client.newRequestDo("PUT", u, nil, &UserPayload{User: user}, &v)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -273,9 +289,9 @@ func (s *UserService) ListContactMethods(userID string) (*ListContactMethodsResp
 // CreateContactMethod creates a new contact method for a user.
 func (s *UserService) CreateContactMethod(userID string, contactMethod *ContactMethod) (*ContactMethod, *Response, error) {
 	u := fmt.Sprintf("/users/%s/contact_methods", userID)
-	v := new(ContactMethod)
+	v := new(ContactMethodPayload)
 
-	resp, err := s.client.newRequestDo("POST", u, nil, &ContactMethod{ContactMethod: contactMethod}, &v)
+	resp, err := s.client.newRequestDo("POST", u, nil, &ContactMethodPayload{ContactMethod: contactMethod}, &v)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -292,10 +308,10 @@ func (s *UserService) CreateContactMethod(userID string, contactMethod *ContactM
 // GetContactMethod retrieves a contact method for a user.
 func (s *UserService) GetContactMethod(userID string, contactMethodID string) (*ContactMethod, *Response, error) {
 	u := fmt.Sprintf("/users/%s/contact_methods/%s", userID, contactMethodID)
-	v := new(ContactMethod)
+	v := new(ContactMethodPayload)
 
 	if err := cacheGetContactMethod(contactMethodID, v); err == nil {
-		return v, nil, nil
+		return v.ContactMethod, nil, nil
 	}
 
 	resp, err := s.client.newRequestDo("GET", u, nil, nil, &v)
@@ -309,9 +325,9 @@ func (s *UserService) GetContactMethod(userID string, contactMethodID string) (*
 // UpdateContactMethod updates a contact method for a user.
 func (s *UserService) UpdateContactMethod(userID, contactMethodID string, contactMethod *ContactMethod) (*ContactMethod, *Response, error) {
 	u := fmt.Sprintf("/users/%s/contact_methods/%s", userID, contactMethodID)
-	v := new(ContactMethod)
+	v := new(ContactMethodPayload)
 
-	resp, err := s.client.newRequestDo("PUT", u, nil, &ContactMethod{ContactMethod: contactMethod}, &v)
+	resp, err := s.client.newRequestDo("PUT", u, nil, &ContactMethodPayload{ContactMethod: contactMethod}, &v)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -338,9 +354,9 @@ func (s *UserService) DeleteContactMethod(userID, contactMethodID string) (*Resp
 // CreateNotificationRule creates a new notification rule for a user.
 func (s *UserService) CreateNotificationRule(userID string, rule *NotificationRule) (*NotificationRule, *Response, error) {
 	u := fmt.Sprintf("/users/%s/notification_rules", userID)
-	v := new(NotificationRule)
+	v := new(NotificationRulePayload)
 
-	resp, err := s.client.newRequestDo("POST", u, nil, &NotificationRule{NotificationRule: rule}, &v)
+	resp, err := s.client.newRequestDo("POST", u, nil, &NotificationRulePayload{NotificationRule: rule}, &v)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -357,10 +373,10 @@ func (s *UserService) CreateNotificationRule(userID string, rule *NotificationRu
 // GetNotificationRule retrieves a notification rule for a user.
 func (s *UserService) GetNotificationRule(userID string, ruleID string) (*NotificationRule, *Response, error) {
 	u := fmt.Sprintf("/users/%s/notification_rules/%s", userID, ruleID)
-	v := new(NotificationRule)
+	v := new(NotificationRulePayload)
 
 	if err := cacheGetNotificationRule(ruleID, v); err == nil {
-		return v, nil, nil
+		return v.NotificationRule, nil, nil
 	}
 
 	resp, err := s.client.newRequestDo("GET", u, nil, nil, &v)
@@ -374,9 +390,9 @@ func (s *UserService) GetNotificationRule(userID string, ruleID string) (*Notifi
 // UpdateNotificationRule updates a notification rulefor a user.
 func (s *UserService) UpdateNotificationRule(userID, ruleID string, rule *NotificationRule) (*NotificationRule, *Response, error) {
 	u := fmt.Sprintf("/users/%s/notification_rules/%s", userID, ruleID)
-	v := new(NotificationRule)
+	v := new(NotificationRulePayload)
 
-	resp, err := s.client.newRequestDo("PUT", u, nil, &NotificationRule{NotificationRule: rule}, &v)
+	resp, err := s.client.newRequestDo("PUT", u, nil, &NotificationRulePayload{NotificationRule: rule}, &v)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pagerduty/user_test.go
+++ b/pagerduty/user_test.go
@@ -42,7 +42,7 @@ func TestUsersCreate(t *testing.T) {
 
 	mux.HandleFunc("/users", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		v := new(User)
+		v := new(UserPayload)
 		json.NewDecoder(r.Body).Decode(v)
 		if !reflect.DeepEqual(v.User, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
@@ -110,7 +110,7 @@ func TestUsersUpdate(t *testing.T) {
 
 	mux.HandleFunc("/users/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
-		v := new(User)
+		v := new(UserPayload)
 		json.NewDecoder(r.Body).Decode(v)
 		if !reflect.DeepEqual(v.User, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
@@ -141,7 +141,7 @@ func TestUsersAddContactMethod(t *testing.T) {
 
 	mux.HandleFunc("/users/1/contact_methods", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		v := new(ContactMethod)
+		v := new(ContactMethodPayload)
 		json.NewDecoder(r.Body).Decode(v)
 		if !reflect.DeepEqual(v.ContactMethod, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
@@ -173,7 +173,7 @@ func TestUsersUpdateContactMethod(t *testing.T) {
 
 	mux.HandleFunc("/users/1/contact_methods/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
-		v := new(ContactMethod)
+		v := new(ContactMethodPayload)
 		json.NewDecoder(r.Body).Decode(v)
 		if !reflect.DeepEqual(v.ContactMethod, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)

--- a/pagerduty/vendor.go
+++ b/pagerduty/vendor.go
@@ -10,19 +10,18 @@ type VendorService service
 
 // Vendor represents a vendor.
 type Vendor struct {
-	Description         string  `json:"description,omitempty"`
-	GenericServiceType  string  `json:"generic_service_type,omitempty"`
-	HTMLURL             string  `json:"html_url,omitempty"`
-	ID                  string  `json:"id,omitempty"`
-	IntegrationGuideURL string  `json:"integration_guide_url,omitempty"`
-	LogoURL             string  `json:"logo_url,omitempty"`
-	Name                string  `json:"name,omitempty"`
-	Self                string  `json:"self,omitempty"`
-	Summary             string  `json:"summary,omitempty"`
-	ThumbnailURL        string  `json:"thumbnail_url,omitempty"`
-	Type                string  `json:"type,omitempty"`
-	Vendor              *Vendor `json:"vendor,omitempty"`
-	WebsiteURL          string  `json:"website_url,omitempty"`
+	Description         string `json:"description,omitempty"`
+	GenericServiceType  string `json:"generic_service_type,omitempty"`
+	HTMLURL             string `json:"html_url,omitempty"`
+	ID                  string `json:"id,omitempty"`
+	IntegrationGuideURL string `json:"integration_guide_url,omitempty"`
+	LogoURL             string `json:"logo_url,omitempty"`
+	Name                string `json:"name,omitempty"`
+	Self                string `json:"self,omitempty"`
+	Summary             string `json:"summary,omitempty"`
+	ThumbnailURL        string `json:"thumbnail_url,omitempty"`
+	Type                string `json:"type,omitempty"`
+	WebsiteURL          string `json:"website_url,omitempty"`
 }
 
 // ListVendorsOptions represents options when listing vendors.
@@ -43,6 +42,11 @@ type ListVendorsResponse struct {
 	Vendors []*Vendor `json:"vendors,omitempty"`
 }
 
+// VendorPayload represents a vendor.
+type VendorPayload struct {
+	Vendor *Vendor `json:"vendor,omitempty"`
+}
+
 // List lists existing vendors.
 func (s *VendorService) List(o *ListVendorsOptions) (*ListVendorsResponse, *Response, error) {
 	u := "/vendors"
@@ -59,7 +63,7 @@ func (s *VendorService) List(o *ListVendorsOptions) (*ListVendorsResponse, *Resp
 // Get retrieves information about a vendor.
 func (s *VendorService) Get(id string) (*Vendor, *Response, error) {
 	u := fmt.Sprintf("/vendors/%s", id)
-	v := new(Vendor)
+	v := new(VendorPayload)
 
 	resp, err := s.client.newRequestDo("GET", u, nil, nil, &v)
 	if err != nil {


### PR DESCRIPTION
Attempt to remove the nested structs in most/if not all remaining places, replacing them with `payload` structs.

Related:
- https://github.com/heimweh/go-pagerduty/issues/57
- https://github.com/heimweh/go-pagerduty/pull/58