### PR TITLE
Add business service subscribers support

### DIFF
--- a/pagerduty/business_service_subscriber.go
+++ b/pagerduty/business_service_subscriber.go
@@ -14,7 +14,7 @@ type BusinessServiceSubscriber struct {
 
 // BusinessServiceSubscriberPayload represents payload with a business service subscriber object
 type BusinessServiceSubscriberPayload struct {
-	BusinessServiceSubscriber  []*BusinessServiceSubscriber `json:"subscribers,omitempty"`
+	BusinessServiceSubscriber []*BusinessServiceSubscriber `json:"subscribers,omitempty"`
 }
 
 // ListBusinessServiceSubscribersResponse represents a list response of business service subscribers.
@@ -68,7 +68,7 @@ func (s *BusinessServiceSubscriberService) Create(businessServiceID string, subs
 	subscriberArr := make([]*BusinessServiceSubscriber, 0)
 	subscriberArr = append(subscriberArr, subscriber)
 	p := &BusinessServiceSubscriberPayload{BusinessServiceSubscriber: subscriberArr}
-	
+
 	resp, err := s.client.newRequestDo("POST", u, nil, p, v)
 	if err != nil {
 		return nil, err

--- a/pagerduty/business_service_subscriber.go
+++ b/pagerduty/business_service_subscriber.go
@@ -1,0 +1,94 @@
+package pagerduty
+
+import "fmt"
+
+// BusinessServiceSubscriberService handles the communication with business service
+// subscriber related methods of the PagerDuty API.
+type BusinessServiceSubscriberService service
+
+// BusinessService represents a business service.
+type BusinessServiceSubscriber struct {
+	ID   string `json:"subscriber_id,omitempty"`
+	Type string `json:"subscriber_type,omitempty"`
+}
+
+// BusinessServiceSubscriberPayload represents payload with a business service subscriber object
+type BusinessServiceSubscriberPayload struct {
+	BusinessServiceSubscriber  []*BusinessServiceSubscriber `json:"subscribers,omitempty"`
+}
+
+// ListBusinessServiceSubscribersResponse represents a list response of business service subscribers.
+type ListBusinessServiceSubscribersResponse struct {
+	Total                      int                          `json:"total,omitempty"`
+	BusinessServiceSubscribers []*BusinessServiceSubscriber `json:"subscribers,omitempty"`
+	Offset                     int                          `json:"offset,omitempty"`
+	More                       bool                         `json:"more,omitempty"`
+	Limit                      int                          `json:"limit,omitempty"`
+}
+
+// List lists existing business service subscribers.
+func (s *BusinessServiceSubscriberService) List(businessServiceID string) (*ListBusinessServiceSubscribersResponse, *Response, error) {
+	u := fmt.Sprintf("/business_services/%s/subscribers", businessServiceID)
+	v := new(ListBusinessServiceSubscribersResponse)
+
+	businessServiceSubscribers := make([]*BusinessServiceSubscriber, 0)
+
+	// Create a handler closure capable of parsing data from the subscribers endpoint
+	// and appending resultant response plays to the return slice.
+	responseHandler := func(response *Response) (ListResp, *Response, error) {
+		var result ListBusinessServiceSubscribersResponse
+
+		if err := s.client.DecodeJSON(response, &result); err != nil {
+			return ListResp{}, response, err
+		}
+
+		businessServiceSubscribers = append(businessServiceSubscribers, result.BusinessServiceSubscribers...)
+
+		// Return stats on the current page. Caller can use this information to
+		// adjust for requesting additional pages.
+		return ListResp{
+			More:   result.More,
+			Offset: result.Offset,
+			Limit:  result.Limit,
+		}, response, nil
+	}
+	err := s.client.newRequestPagedGetDo(u, responseHandler)
+	if err != nil {
+		return nil, nil, err
+	}
+	v.BusinessServiceSubscribers = businessServiceSubscribers
+
+	return v, nil, nil
+}
+
+// Create creates a new business service subscriber.
+func (s *BusinessServiceSubscriberService) Create(businessServiceID string, subscriber *BusinessServiceSubscriber) (*Response, error) {
+	u := fmt.Sprintf("/business_services/%s/subscribers", businessServiceID)
+	v := new(BusinessServiceSubscriberPayload)
+	subscriberArr := make([]*BusinessServiceSubscriber, 0)
+	subscriberArr = append(subscriberArr, subscriber)
+	p := &BusinessServiceSubscriberPayload{BusinessServiceSubscriber: subscriberArr}
+	
+	resp, err := s.client.newRequestDo("POST", u, nil, p, v)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// Delete deletes a business service subscriber.
+func (s *BusinessServiceSubscriberService) Delete(businessServiceID string, subscriber *BusinessServiceSubscriber) (*Response, error) {
+	u := fmt.Sprintf("/business_services/%s/unsubscribe", businessServiceID)
+	v := new(BusinessServiceSubscriberPayload)
+	subscriberArr := make([]*BusinessServiceSubscriber, 0)
+	subscriberArr = append(subscriberArr, subscriber)
+	p := &BusinessServiceSubscriberPayload{BusinessServiceSubscriber: subscriberArr}
+
+	resp, err := s.client.newRequestDo("POST", u, nil, p, v)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}

--- a/pagerduty/business_service_subscriber_test.go
+++ b/pagerduty/business_service_subscriber_test.go
@@ -1,0 +1,88 @@
+package pagerduty
+
+import (
+	"encoding/json"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestBusinessServiceSubscriberList(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/business_services/1/subscribers", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		w.Write([]byte(`{"total": 0, "offset": 0, "more": false, "limit": 0, "subscribers":[{"subscriber_id": "1", "subscriber_type": "team"}]}`))
+	})
+
+	resp, _, err := client.BusinessServiceSubscribers.List("1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &ListBusinessServiceSubscribersResponse{
+		Total:  0,
+		Offset: 0,
+		More:   false,
+		Limit:  0,
+		BusinessServiceSubscribers: []*BusinessServiceSubscriber{
+			{
+				ID: "1",
+				Type: "team",
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(resp, want) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp, want)
+	}
+}
+
+func TestBusinessServiceSubscriberCreate(t *testing.T) {
+	setup()
+	defer teardown()
+	input := &BusinessServiceSubscriber{ID: "foo", Type: "team"}
+	businessServiceID := "1"
+
+	mux.HandleFunc("/business_services/1/subscribers", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		v := new(BusinessServiceSubscriber)
+		v.ID = "foo"
+		v.Type = "team"
+		json.NewDecoder(r.Body).Decode(v)
+		if !reflect.DeepEqual(v, input) {
+			t.Errorf("Request body = %+v, want %+v", v, input)
+		}
+		w.Write([]byte(`{"account_is_subscribed": true}`))
+	})
+	// this endpoint only returns  an "ok" in the body. no point in testing for it.
+	if _, err := client.BusinessServiceSubscribers.Create(businessServiceID, input); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestBusinessServiceSubscriberDelete(t *testing.T) {
+	setup()
+	defer teardown()
+
+	businessServiceID := "1"
+	subscriber := &BusinessServiceSubscriber{ID: "foo", Type: "team"}
+
+	mux.HandleFunc("/business_services/1/unsubscribe", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		v := new(BusinessServiceSubscriber)
+		v.ID = "foo"
+		v.Type = "team"
+		json.NewDecoder(r.Body).Decode(v)
+		if !reflect.DeepEqual(v, subscriber) {
+			t.Errorf("Request body = %+v, want %+v", v, subscriber)
+		}
+		w.Write([]byte(`{"deleted_count": 1, "unauthorized_count": 1, "non_existent_count": 0}`))
+	})
+
+	// this endpoint only returns  an "ok" in the body. no point in testing for it.
+	if _, err := client.BusinessServiceSubscribers.Delete(businessServiceID, subscriber); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pagerduty/business_service_subscriber_test.go
+++ b/pagerduty/business_service_subscriber_test.go
@@ -28,7 +28,7 @@ func TestBusinessServiceSubscriberList(t *testing.T) {
 		Limit:  0,
 		BusinessServiceSubscribers: []*BusinessServiceSubscriber{
 			{
-				ID: "1",
+				ID:   "1",
 				Type: "team",
 			},
 		},

--- a/pagerduty/cache.go
+++ b/pagerduty/cache.go
@@ -100,7 +100,7 @@ func PopulateMemoryCache() {
 			Abilities: abilities,
 		}
 		cachePut("misc", "abilities", abilitiesRecord)
-		
+
 		var pdo = ListUsersOptions{
 			Include: []string{"contact_methods", "notification_rules"},
 			Limit:   100,

--- a/pagerduty/pagerduty.go
+++ b/pagerduty/pagerduty.go
@@ -32,28 +32,29 @@ type Config struct {
 
 // Client manages the communication with the PagerDuty API
 type Client struct {
-	baseURL             *url.URL
-	client              *http.Client
-	Config              *Config
-	Abilities           *AbilityService
-	Addons              *AddonService
-	EscalationPolicies  *EscalationPolicyService
-	Extensions          *ExtensionService
-	MaintenanceWindows  *MaintenanceWindowService
-	Rulesets            *RulesetService
-	Schedules           *ScheduleService
-	Services            *ServicesService
-	Teams               *TeamService
-	ExtensionSchemas    *ExtensionSchemaService
-	Users               *UserService
-	Vendors             *VendorService
-	EventRules          *EventRuleService
-	BusinessServices    *BusinessServiceService
-	ServiceDependencies *ServiceDependencyService
-	Priorities          *PriorityService
-	ResponsePlays       *ResponsePlayService
-	SlackConnections    *SlackConnectionService
-	Tags                *TagService
+	baseURL                    *url.URL
+	client                     *http.Client
+	Config                     *Config
+	Abilities                  *AbilityService
+	Addons                     *AddonService
+	EscalationPolicies         *EscalationPolicyService
+	Extensions                 *ExtensionService
+	MaintenanceWindows         *MaintenanceWindowService
+	Rulesets                   *RulesetService
+	Schedules                  *ScheduleService
+	Services                   *ServicesService
+	Teams                      *TeamService
+	ExtensionSchemas           *ExtensionSchemaService
+	Users                      *UserService
+	Vendors                    *VendorService
+	EventRules                 *EventRuleService
+	BusinessServices           *BusinessServiceService
+	ServiceDependencies        *ServiceDependencyService
+	Priorities                 *PriorityService
+	ResponsePlays              *ResponsePlayService
+	SlackConnections           *SlackConnectionService
+	Tags                       *TagService
+	BusinessServiceSubscribers *BusinessServiceSubscriberService
 }
 
 // Response is a wrapper around http.Response
@@ -111,6 +112,7 @@ func NewClient(config *Config) (*Client, error) {
 	c.ResponsePlays = &ResponsePlayService{c}
 	c.SlackConnections = &SlackConnectionService{c}
 	c.Tags = &TagService{c}
+	c.BusinessServiceSubscribers = &BusinessServiceSubscriberService{c}
 
 	InitCache(c)
 	PopulateCache()


### PR DESCRIPTION
```
=== RUN   TestBusinessServiceSubscriberList
2021/10/28 19:42:39 ===== Enabling PagerDuty memory cache =====
--- PASS: TestBusinessServiceSubscriberList (0.00s)
=== RUN   TestBusinessServiceSubscriberCreate
2021/10/28 19:42:39 ===== Enabling PagerDuty memory cache =====
--- PASS: TestBusinessServiceSubscriberCreate (0.00s)
=== RUN   TestBusinessServiceSubscriberDelete
2021/10/28 19:42:39 ===== Enabling PagerDuty memory cache =====
--- PASS: TestBusinessServiceSubscriberDelete (0.00s)
```

To be used in https://github.com/PagerDuty/terraform-provider-pagerduty/pull/414

Related https://github.com/PagerDuty/terraform-provider-pagerduty/issues/390