### PR TITLE
Ensure business service subscription was successful by checking response body

### DIFF
--- a/pagerduty/business_service_subscriber.go
+++ b/pagerduty/business_service_subscriber.go
@@ -91,11 +91,17 @@ func (s *BusinessServiceSubscriberService) Create(businessServiceID string, subs
 		return nil, err
 	}
 
-	subscriptionResp := result.BusinessServiceSubscriber[0]
+	subscriptionResp := result.BusinessServiceSubscriber
+	errorMessage := ""
+	for _, subscription := range subscriptionResp {
+		if subscription.Result != "success" {
+			// append error message to message variable
+			errorMessage = errorMessage + fmt.Sprintf("resulting status for subscription of %s %s to %s %s was: %s. ", subscription.Type, subscription.ID, subscription.SubscribableType, subscription.SubscribableID, subscription.Result)
+		}
+	}
 
-	if subscriptionResp.Result != "success" {
-		message := fmt.Sprintf("resulting status of the subscription was: %s", subscriptionResp.Result)
-		return nil, errors.New(message)
+	if errorMessage != "" {
+		return nil, errors.New(errorMessage)
 	}
 
 	return resp, nil

--- a/pagerduty/business_service_subscriber.go
+++ b/pagerduty/business_service_subscriber.go
@@ -1,6 +1,9 @@
 package pagerduty
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
 
 // BusinessServiceSubscriberService handles the communication with business service
 // subscriber related methods of the PagerDuty API.
@@ -8,13 +11,21 @@ type BusinessServiceSubscriberService service
 
 // BusinessService represents a business service.
 type BusinessServiceSubscriber struct {
-	ID   string `json:"subscriber_id,omitempty"`
-	Type string `json:"subscriber_type,omitempty"`
+	ID               string `json:"subscriber_id,omitempty"`
+	Type             string `json:"subscriber_type,omitempty"`
+	SubscribableID   string `json:"subscribable_id,omitempty"`
+	SubscribableType string `json:"subscribable_type,omitempty"`
+	Result           string `json:"result,omitempty"`
 }
 
 // BusinessServiceSubscriberPayload represents payload with a business service subscriber object
 type BusinessServiceSubscriberPayload struct {
 	BusinessServiceSubscriber []*BusinessServiceSubscriber `json:"subscribers,omitempty"`
+}
+
+// CreateBusinessServiceSubscribersResponse represents a create response of business service subscription result.
+type CreateBusinessServiceSubscribersResponse struct {
+	BusinessServiceSubscriber []*BusinessServiceSubscriber `json:"subscriptions,omitempty"`
 }
 
 // ListBusinessServiceSubscribersResponse represents a list response of business service subscribers.
@@ -72,6 +83,19 @@ func (s *BusinessServiceSubscriberService) Create(businessServiceID string, subs
 	resp, err := s.client.newRequestDo("POST", u, nil, p, v)
 	if err != nil {
 		return nil, err
+	}
+
+	var result CreateBusinessServiceSubscribersResponse
+
+	if err := s.client.DecodeJSON(resp, &result); err != nil {
+		return nil, err
+	}
+
+	subscriptionResp := result.BusinessServiceSubscriber[0]
+
+	if subscriptionResp.Result != "success" {
+		message := fmt.Sprintf("resulting status of the subscription was: %s", subscriptionResp.Result)
+		return nil, errors.New(message)
 	}
 
 	return resp, nil


### PR DESCRIPTION
Add CreateBusinessServiceSubscribersResponse and ensure that resulting status of all the subscriptions is success. The Create Business Service Subscribers API endpoint will return 200 OK even if a subscription did not create, because it is designed to accept multiple subscriptions for users and teams in one request.

For https://github.com/PagerDuty/terraform-provider-pagerduty/pull/414, it is only being used to send one subscription in a single request. So we must check that no subscriptions failed in the request

200 OK response includes:
result, string,  The resulting status of the subscription
Allowed values: success, duplicate, unauthorized

https://developer.pagerduty.com/api-reference/b3A6NDUwNDgyMA-create-business-service-subscribers

Example of 200 OK response body:
```json
{
 "subscriptions": [
  {
   "account_id": "PQL6MPB",
   "result": "unauthorized",
   "subscribable_id": "P3D3U4T",
   "subscribable_type": "business_service",
   "subscriber_id": "PGW87TJ",
   "subscriber_type": "team"
  }
 ]
}
```