### PR TITLE
UserService-CreateContactMethod: allow using existing contact methods

### DIFF
--- a/pagerduty/user_test.go
+++ b/pagerduty/user_test.go
@@ -165,6 +165,50 @@ func TestUsersAddContactMethod(t *testing.T) {
 	}
 }
 
+func TestUsersAddDuplicateContactMethod(t *testing.T) {
+	setup()
+	defer teardown()
+
+	input := &ContactMethod{Address: "foo@bar.com", Type: "email_contact_method"}
+
+	mux.HandleFunc("/users/1/contact_methods", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "POST" {
+			v := new(ContactMethodPayload)
+			json.NewDecoder(r.Body).Decode(v)
+			if !reflect.DeepEqual(v.ContactMethod, input) {
+				t.Errorf("Request body = %+v, want %+v", v, input)
+			}
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte(`{"error":{"errors":["User Contact method must be unique"],"code":2001,"message":"Invalid Input Provided"}}`))
+		} else if r.Method == "GET" {
+			w.Write([]byte(`{"contact_methods": [{ "address": "foo@bar.com", "id": "1", "type": "email_contact_method", "self":"api/users/1/contact_methods/1" }] }`))
+		} else {
+			t.Errorf("Request method : %v is neither POST nor GET", r.Method)
+		}
+	})
+
+	mux.HandleFunc("/users/1/contact_methods/1", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		w.Write([]byte(`{"contact_method": { "address": "foo@bar.com", "id": "1", "type": "email_contact_method", "self":"api/users/1/contact_methods/1" }}`))
+	})
+
+	resp, _, err := client.Users.CreateContactMethod("1", input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &ContactMethod{
+		ID:      "1",
+		Type:    "email_contact_method",
+		Address: "foo@bar.com",
+		Self:    "api/users/1/contact_methods/1",
+	}
+
+	if !reflect.DeepEqual(resp, want) {
+		t.Errorf("returned %#v; want %#v", resp, want)
+	}
+}
+
 func TestUsersUpdateContactMethod(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
Previously, if the new contact method is duplicate, the method will fail. This change allows to first
check if the existing contact method and the new one to be added is the same, if so, fetch the existing one
and return successfully.

This feature is useful in terraform provider, as it can sync existing contact methods automatically to terraform
states.