### PR TITLE
Enable schedule_layer's end to be null in the JSON encoding

### DIFF
--- a/pagerduty/schedule.go
+++ b/pagerduty/schedule.go
@@ -58,7 +58,8 @@ type ScheduleLayerEntry struct {
 
 // ScheduleLayer represents a schedule layer in a schedule
 type ScheduleLayer struct {
-	End                        string                  `json:"end,omitempty"`
+	// End should be nullable because if it's null, it means the layer does not end.
+	End                        *string                 `json:"end"`
 	ID                         string                  `json:"id,omitempty"`
 	Name                       string                  `json:"name,omitempty"`
 	RenderedCoveragePercentage float64                 `json:"rendered_coverage_percentage,omitempty"`

--- a/pagerduty/schedule_test.go
+++ b/pagerduty/schedule_test.go
@@ -110,8 +110,12 @@ func TestSchedulesUpdate(t *testing.T) {
 
 	input := &Schedule{
 		Name: "foo",
+		ScheduleLayers: []*ScheduleLayer{
+			&ScheduleLayer{
+				Name: "Layer1",
+			},
+		},
 	}
-
 	mux.HandleFunc("/schedules/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
 		v := new(SchedulePayload)
@@ -119,7 +123,7 @@ func TestSchedulesUpdate(t *testing.T) {
 		if !reflect.DeepEqual(v.Schedule, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
-		w.Write([]byte(`{"schedule": {"name": "foo", "id": "1"}}`))
+		w.Write([]byte(`{"schedule": {"name": "foo", "id": "1", "schedule_layers": [{"name": "Layer1", "End": null}]}}`))
 	})
 
 	resp, _, err := client.Schedules.Update("1", input, &UpdateScheduleOptions{})
@@ -130,6 +134,11 @@ func TestSchedulesUpdate(t *testing.T) {
 	want := &Schedule{
 		Name: "foo",
 		ID:   "1",
+		ScheduleLayers: []*ScheduleLayer{
+			&ScheduleLayer{
+				Name: "Layer1",
+			},
+		},
 	}
 
 	if !reflect.DeepEqual(resp, want) {


### PR DESCRIPTION
# What

* Enable schedule_layer's end to be null in the JSON encoding

# Why

* `end: null` means the layer doesn't end in the endpoint `schedules/{id}`.
![image](https://user-images.githubusercontent.com/1156179/151420035-624b4dde-88a9-4abf-864a-ec41cd138f4d.png)
  from https://developer.pagerduty.com/api-reference/b3A6Mjc0ODE4NQ-update-a-schedule
* https://github.com/PagerDuty/terraform-provider-pagerduty/issues/451 is a related issue. The PagerDuty terraform provider doesn't send `end: null` even when `pagerduty_schedule.layer.end` was deleted.