### PR TITLE
remove `omitempty` from `CustomHeaders` field

### DIFF
--- a/pagerduty/webhook_subscription.go
+++ b/pagerduty/webhook_subscription.go
@@ -21,7 +21,7 @@ type DeliveryMethod struct {
 	TemporarilyDisabled bool             `json:"temporarily_disabled,omitempty"`
 	Type                string           `json:"type,omitempty"`
 	URL                 string           `json:"url,omitempty"`
-	CustomHeaders       []*CustomHeaders `json:"custom_headers,omitempty"`
+	CustomHeaders       []*CustomHeaders `json:"custom_headers"`
 }
 
 type CustomHeaders struct {


### PR DESCRIPTION
this fixes: https://github.com/heimweh/go-pagerduty/pull/81#issuecomment-1032188377