### PR TITLE
add response_play field to service

### DIFF
--- a/pagerduty/references.go
+++ b/pagerduty/references.go
@@ -19,6 +19,9 @@ type UserReference resourceReference
 // EscalationPolicyReference represents a reference to an escalation policy.
 type EscalationPolicyReference resourceReference
 
+// ResponsePlayReference represents a reference to a response play.
+type ResponsePlayReference resourceReference
+
 // ScheduleReference represents a reference to a schedule.
 type ScheduleReference resourceReference
 

--- a/pagerduty/service.go
+++ b/pagerduty/service.go
@@ -133,6 +133,7 @@ type Service struct {
 	CreatedAt               string                     `json:"created_at,omitempty"`
 	Description             string                     `json:"description,omitempty"`
 	EscalationPolicy        *EscalationPolicyReference `json:"escalation_policy,omitempty"`
+	ResponsePlay            *ResponsePlayReference     `json:"response_play,omitempty"`
 	HTMLURL                 string                     `json:"html_url,omitempty"`
 	ID                      string                     `json:"id,omitempty"`
 	IncidentUrgencyRule     *IncidentUrgencyRule       `json:"incident_urgency_rule,omitempty"`

--- a/pagerduty/service_fixtures_test.go
+++ b/pagerduty/service_fixtures_test.go
@@ -55,6 +55,13 @@ const (
           "urgency": "low"
         }
       },
+      "response_play": {
+        "id": "6c5d755a-32a0-4f55-8fe8-26fd6b504698",
+        "type":    "response_play_reference",
+        "summary": "A Response Play",
+        "self":    "https://api.pagerduty.com/response_plays/6c5d755a-32a0-4f55-8fe8-26fd6b504698",
+        "html_url": "https://subdomain.pagerduty.com/response_plays/6c5d755a-32a0-4f55-8fe8-26fd6b504698"
+      },
       "support_hours": {
         "type": "fixed_time_per_day",
         "time_zone": "America/Lima",
@@ -183,6 +190,13 @@ var (
 				},
 				LastIncidentTimestamp: "",
 				Name:                  "My Application Service",
+				ResponsePlay: &ResponsePlayReference{
+					ID:      "6c5d755a-32a0-4f55-8fe8-26fd6b504698",
+					Type:    "response_play_reference",
+					Summary: "A Response Play",
+					Self:    "https://api.pagerduty.com/response_plays/6c5d755a-32a0-4f55-8fe8-26fd6b504698",
+					HTMLURL: "https://subdomain.pagerduty.com/response_plays/6c5d755a-32a0-4f55-8fe8-26fd6b504698",
+				},
 				ScheduledActions: []*ScheduledAction{
 					{
 						Type: "urgency_change",


### PR DESCRIPTION
This PR adds the response_play field to the service object, which has been added to the API recently to allow associating a response play with a service:
[create](https://developer.pagerduty.com/api-reference/7062f2631b397-create-a-service), [update](https://developer.pagerduty.com/api-reference/fbc6e9f4ef8eb-update-a-service) and [get](https://developer.pagerduty.com/api-reference/165ad96a22ffd-get-a-service)

please let me know if there's anything else to add