### PR TITLE
Add support for service level auto_pause_notifications_parameters

### DIFF
--- a/pagerduty/service.go
+++ b/pagerduty/service.go
@@ -49,6 +49,12 @@ type AlertGroupingParameters struct {
 	Config *AlertGroupingConfig `json:"config,omitempty"`
 }
 
+// AutoPauseNotificationsParameters defines how alerts on this service are automatically suspended for a period of time before triggering, when identified as likely being transient.
+type AutoPauseNotificationsParameters struct {
+	Enabled bool `json:enabled,omitempty`
+	Timeout int  `json:timeout,omitempty`
+}
+
 // IncidentUrgencyRule is the default urgency for new incidents.
 type IncidentUrgencyRule struct {
 	DuringSupportHours  *IncidentUrgencyType `json:"during_support_hours,omitempty"`
@@ -123,29 +129,30 @@ type ValueExtractor struct {
 
 // Service represents a service.
 type Service struct {
-	AcknowledgementTimeout  *int                       `json:"acknowledgement_timeout"`
-	Addons                  []*AddonReference          `json:"addons,omitempty"`
-	AlertCreation           string                     `json:"alert_creation,omitempty"`
-	AlertGrouping           *string                    `json:"alert_grouping"`
-	AlertGroupingTimeout    *int                       `json:"alert_grouping_timeout,omitempty"`
-	AlertGroupingParameters *AlertGroupingParameters   `json:"alert_grouping_parameters,omitempty"`
-	AutoResolveTimeout      *int                       `json:"auto_resolve_timeout"`
-	CreatedAt               string                     `json:"created_at,omitempty"`
-	Description             string                     `json:"description,omitempty"`
-	EscalationPolicy        *EscalationPolicyReference `json:"escalation_policy,omitempty"`
-	HTMLURL                 string                     `json:"html_url,omitempty"`
-	ID                      string                     `json:"id,omitempty"`
-	IncidentUrgencyRule     *IncidentUrgencyRule       `json:"incident_urgency_rule,omitempty"`
-	Integrations            []*IntegrationReference    `json:"integrations,omitempty"`
-	LastIncidentTimestamp   string                     `json:"last_incident_timestamp,omitempty"`
-	Name                    string                     `json:"name,omitempty"`
-	ScheduledActions        []*ScheduledAction         `json:"scheduled_actions,omitempty"`
-	Self                    string                     `json:"self,omitempty"`
-	Status                  string                     `json:"status,omitempty"`
-	Summary                 string                     `json:"summary,omitempty"`
-	SupportHours            *SupportHours              `json:"support_hours,omitempty"`
-	Teams                   []*TeamReference           `json:"teams,omitempty"`
-	Type                    string                     `json:"type,omitempty"`
+	AcknowledgementTimeout           *int                              `json:"acknowledgement_timeout"`
+	Addons                           []*AddonReference                 `json:"addons,omitempty"`
+	AlertCreation                    string                            `json:"alert_creation,omitempty"`
+	AlertGrouping                    *string                           `json:"alert_grouping"`
+	AlertGroupingTimeout             *int                              `json:"alert_grouping_timeout,omitempty"`
+	AlertGroupingParameters          *AlertGroupingParameters          `json:"alert_grouping_parameters,omitempty"`
+	AutoPauseNotificationsParameters *AutoPauseNotificationsParameters `json:"auto_pause_notifications_parameters,omitempty"`
+	AutoResolveTimeout               *int                              `json:"auto_resolve_timeout"`
+	CreatedAt                        string                            `json:"created_at,omitempty"`
+	Description                      string                            `json:"description,omitempty"`
+	EscalationPolicy                 *EscalationPolicyReference        `json:"escalation_policy,omitempty"`
+	HTMLURL                          string                            `json:"html_url,omitempty"`
+	ID                               string                            `json:"id,omitempty"`
+	IncidentUrgencyRule              *IncidentUrgencyRule              `json:"incident_urgency_rule,omitempty"`
+	Integrations                     []*IntegrationReference           `json:"integrations,omitempty"`
+	LastIncidentTimestamp            string                            `json:"last_incident_timestamp,omitempty"`
+	Name                             string                            `json:"name,omitempty"`
+	ScheduledActions                 []*ScheduledAction                `json:"scheduled_actions,omitempty"`
+	Self                             string                            `json:"self,omitempty"`
+	Status                           string                            `json:"status,omitempty"`
+	Summary                          string                            `json:"summary,omitempty"`
+	SupportHours                     *SupportHours                     `json:"support_hours,omitempty"`
+	Teams                            []*TeamReference                  `json:"teams,omitempty"`
+	Type                             string                            `json:"type,omitempty"`
 }
 
 // ServicePayload represents a service.


### PR DESCRIPTION
This PR adds support for service level `auto_pause_notifications_parameters` / `AutoPauseNotificationsParameters`

Reference documentation:
* https://support.pagerduty.com/docs/auto-pause-incident-notifications
* https://developer.pagerduty.com/api-reference/7062f2631b397-create-a-service
* https://developer-v2.pd-staging.com/api-reference/c2NoOjE1NDg1MDc1-auto-pause-notifications-parameters