### PR TITLE
Fix auto_pause_notifications_parameters JSON serialization

### DIFF
--- a/pagerduty/service.go
+++ b/pagerduty/service.go
@@ -52,7 +52,7 @@ type AlertGroupingParameters struct {
 // AutoPauseNotificationsParameters defines how alerts on this service are automatically suspended for a period of time before triggering, when identified as likely being transient.
 type AutoPauseNotificationsParameters struct {
 	Enabled bool `json:"enabled"`
-	Timeout int  `json:"timeout"`
+	Timeout *int `json:"timeout"`
 }
 
 // IncidentUrgencyRule is the default urgency for new incidents.

--- a/pagerduty/service.go
+++ b/pagerduty/service.go
@@ -51,8 +51,8 @@ type AlertGroupingParameters struct {
 
 // AutoPauseNotificationsParameters defines how alerts on this service are automatically suspended for a period of time before triggering, when identified as likely being transient.
 type AutoPauseNotificationsParameters struct {
-	Enabled bool `json:"enabled,omitempty"`
-	Timeout int  `json:"timeout,omitempty"`
+	Enabled bool `json:"enabled"`
+	Timeout int  `json:"timeout"`
 }
 
 // IncidentUrgencyRule is the default urgency for new incidents.

--- a/pagerduty/service.go
+++ b/pagerduty/service.go
@@ -51,8 +51,8 @@ type AlertGroupingParameters struct {
 
 // AutoPauseNotificationsParameters defines how alerts on this service are automatically suspended for a period of time before triggering, when identified as likely being transient.
 type AutoPauseNotificationsParameters struct {
-	Enabled bool `json:enabled,omitempty`
-	Timeout int  `json:timeout,omitempty`
+	Enabled bool `json:"enabled,omitempty"`
+	Timeout int  `json:"timeout,omitempty"`
 }
 
 // IncidentUrgencyRule is the default urgency for new incidents.


### PR DESCRIPTION
@stmcallister this PR fixes my previous #92 PR which had broken JSON serialization:

```
---[ REQUEST ]---------------------------------------
POST /services HTTP/1.1
Host: api.pagerduty.com
User-Agent: heimweh/go-pagerduty(terraform)
Content-Length: 323
Accept: application/vnd.pagerduty+json;version=2
Authorization: Token token=******
Content-Type: application/json
Accept-Encoding: gzip

{
 "service": {
  "acknowledgement_timeout": 1800,
  "alert_creation": "create_alerts_and_incidents",
  "alert_grouping": null,
  "auto_pause_notifications_parameters": {
   "Enabled": true,
   "Timeout": 300
  },
  "auto_resolve_timeout": 1800,
  "description": "foo",
  "escalation_policy": {
   "id": "PH58XGR",
   "type": "escalation_policy_reference"
  },
  "name": "tf-lrjyc"
 }
}

-----------------------------------------------------
2022/06/10 14:10:38 [DEBUG] PagerDuty API Response Details:
---[ RESPONSE ]--------------------------------------
HTTP/2.0 400 Bad Request
Content-Length: 116
Access-Control-Allow-Headers: Authorization, Content-Type, AuthorizationOauth, X-EARLY-ACCESS
Access-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS
Access-Control-Allow-Origin: *
Access-Control-Expose-Headers:
Access-Control-Max-Age: 1728000
Cache-Control: no-cache
Content-Type: application/json
Date: Fri, 10 Jun 2022 12:10:38 GMT
Referrer-Policy: strict-origin-when-cross-origin
Server: nginx
X-Request-Id: 088c962e05cb40e17f3a6854672584f2

{
 "error": {
  "message": "Invalid Input Provided",
  "code": 2001,
  "errors": [
   "Enabled must be a TrueClass or a FalseClass."
  ]
 }
}
-----------------------------------------------------

```

Note that `Enabled` and `Timeout` have a capital letter.
