### PR TITLE
add support for oncalls list

### DIFF
--- a/pagerduty/oncall.go
+++ b/pagerduty/oncall.go
@@ -1,0 +1,52 @@
+package pagerduty
+
+// OnCallService handles the communication with team
+// related methods of the PagerDuty API.
+type OnCallService service
+
+// OnCall represents an oncall.
+type OnCall struct {
+	User             *UserReference             `json:"user,omitempty"`
+	Schedule         *ScheduleReference         `json:"schedule,omitemtpy"`
+	EscalationPolicy *EscalationPolicyReference `json:"escalation_policy,omitempty"`
+	EscalationLevel  int                        `json:"escalation_level"`
+	Start            *string                    `json:"start"`
+	End              *string                    `json:"end"`
+}
+
+// ListOnCallOptions represents options when listing oncalls.
+type ListOnCallOptions struct {
+	Limit               int      `url:"limit,omitempty"`
+	Offset              int      `url:"offset,omitempty"`
+	Total               bool     `url:"total,omitempty"`
+	Earliest            bool     `url:"earliest,omitempty"`
+	EscalationPolicyIds []string `url:"escalation_policy_ids,omitempty"`
+	Includes            []string `url:"include,omitempty"`
+	ScheduleIds         []string `url:"schedule_ids,omitempty"`
+	UserIds             []string `url:"user_ids,brackets,omitempty"`
+	Since               string   `url:"since,omitempty"`
+	TimeZone            string   `url:"time_zone,omitempty"`
+	Until               string   `url:"until,omitempty"`
+}
+
+// ListOnCallResponse represents a list response of oncalls.
+type ListOnCallResponse struct {
+	Oncalls []*OnCall `json:"oncalls,omitempty"`
+	Limit   int       `json:"limit,omitempty"`
+	More    bool      `json:"more,omitempty"`
+	Offset  int       `json:"offset,omitempty"`
+	Total   int       `json:"total,omitempty"`
+}
+
+// List lists existing oncalls.
+func (s *OnCallService) List(o *ListOnCallOptions) (*ListOnCallResponse, *Response, error) {
+	u := "/oncalls"
+	v := new(ListOnCallResponse)
+
+	resp, err := s.client.newRequestDo("GET", u, o, nil, &v)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v, resp, nil
+}

--- a/pagerduty/oncall_test.go
+++ b/pagerduty/oncall_test.go
@@ -1,0 +1,38 @@
+package pagerduty
+
+import (
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestOnCallList(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/oncalls", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		w.Write([]byte(`{"oncalls":[{"escalation_level":2,"start":"2015-03-06T15:28:51-05:00","end":"2015-03-07T15:28:51-05:00"}]}`))
+	})
+
+	resp, _, err := client.OnCall.List(&ListOnCallOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	start := "2015-03-06T15:28:51-05:00"
+	end := "2015-03-07T15:28:51-05:00"
+	want := &ListOnCallResponse{
+		Oncalls: []*OnCall{
+			{
+				EscalationLevel: 2,
+				Start:           &start,
+				End:             &end,
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(resp, want) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp, want)
+	}
+}

--- a/pagerduty/pagerduty.go
+++ b/pagerduty/pagerduty.go
@@ -58,6 +58,7 @@ type Client struct {
 	Tags                       *TagService
 	WebhookSubscriptions       *WebhookSubscriptionService
 	BusinessServiceSubscribers *BusinessServiceSubscriberService
+	OnCall                     *OnCallService
 }
 
 // Response is a wrapper around http.Response
@@ -119,6 +120,7 @@ func NewClient(config *Config) (*Client, error) {
 	c.Tags = &TagService{c}
 	c.WebhookSubscriptions = &WebhookSubscriptionService{c}
 	c.BusinessServiceSubscribers = &BusinessServiceSubscriberService{c}
+	c.OnCall = &OnCallService{c}
 
 	InitCache(c)
 	PopulateCache()


### PR DESCRIPTION
This PR add support for list `/oncalls` endpoint.

Reference documentation:

* https://developer.pagerduty.com/api-reference/3a6b910f11050-list-all-of-the-on-calls
* https://developer-v2.pd-staging.com/api-reference/c2NoOjI3NDg0ODM-oncall