### PR TITLE
handle error user contact method must be unique

### DIFF
--- a/pagerduty/user.go
+++ b/pagerduty/user.go
@@ -366,11 +366,11 @@ func (s *UserService) findExistingContactMethod(userID string, contactMethod *Co
 
 	for _, contact := range lResp.ContactMethods {
 		if isSameContactMethod(contact, contactMethod) {
-			return s.GetContactMethod(userID, contact.ID)
+			return nil, nil, fmt.Errorf("[User Contact method must be unique]")
 		}
 	}
 
-	return nil, nil, fmt.Errorf("[User Contact method must be unique]")
+	return s.GetContactMethod(userID, contactMethod.ID)
 }
 
 // isSameContactMethod checks if an existing contact method should be taken as the same as a new one users want to create.


### PR DESCRIPTION
Address: Handling of error **"User Contact method must be unique"** not being correctly managed, because the flow control for doing the evaluation to return the error was inverted.

It was needed to replace the obsolete test case `TestUsersAddDuplicateContactMethod`, because this test case is based on the premise that adding duplicated contact methods is actually allowed and desired, being that this is an unwanted behaviour and the error "User Contact method must be unique" should be returned.

This update introduces `TestUsersErrorWhenContactMethodExists` as test case to validate the expected result in this case, which is returning the error "User Contact method must be unique".

![Screenshot 2022-11-08 at 22 56 55](https://user-images.githubusercontent.com/24704624/200718107-833c5b9b-3bbf-4094-b511-261e8a94474f.png)
