### PR TITLE
incident workflows in go client

### DIFF
--- a/pagerduty/incident_workflow.go
+++ b/pagerduty/incident_workflow.go
@@ -1,0 +1,207 @@
+package pagerduty
+
+import (
+	"context"
+	"fmt"
+)
+
+// IncidentWorkflowService handles the communication with incident workflow
+// related methods of the PagerDuty API.
+type IncidentWorkflowService service
+
+// IncidentWorkflow represents an incident workflow.
+type IncidentWorkflow struct {
+	ID          string                  `json:"id,omitempty"`
+	Type        string                  `json:"type,omitempty"`
+	Name        string                  `json:"name,omitempty"`
+	Description *string                 `json:"description,omitempty"`
+	Self        string                  `json:"self,omitempty"`
+	Steps       []*IncidentWorkflowStep `json:"steps,omitempty"`
+}
+
+// IncidentWorkflowStep represents a step in an incident workflow.
+type IncidentWorkflowStep struct {
+	ID            string                               `json:"id,omitempty"`
+	Type          string                               `json:"type,omitempty"`
+	Name          string                               `json:"name,omitempty"`
+	Description   *string                              `json:"description,omitempty"`
+	Configuration *IncidentWorkflowActionConfiguration `json:"action_configuration,omitempty"`
+}
+
+// IncidentWorkflowActionConfiguration represents the configuration for an incident workflow action
+type IncidentWorkflowActionConfiguration struct {
+	ActionID    string                         `json:"action_id,omitempty"`
+	Description *string                        `json:"description,omitempty"`
+	Inputs      []*IncidentWorkflowActionInput `json:"inputs,omitempty"`
+}
+
+type IncidentWorkflowActionInput struct {
+	Name  string `json:"name,omitempty"`
+	Value string `json:"value,omitempty"`
+}
+
+// ListIncidentWorkflowResponse represents a list response of incident workflows.
+type ListIncidentWorkflowResponse struct {
+	Total             int                 `json:"total,omitempty"`
+	IncidentWorkflows []*IncidentWorkflow `json:"incident_workflows,omitempty"`
+	Offset            int                 `json:"offset,omitempty"`
+	More              bool                `json:"more,omitempty"`
+	Limit             int                 `json:"limit,omitempty"`
+}
+
+// IncidentWorkflowPayload represents payload with an incident workflow object.
+type IncidentWorkflowPayload struct {
+	IncidentWorkflow *IncidentWorkflow `json:"incident_workflow,omitempty"`
+}
+
+var incidentWorkflowsEarlyAccessHeader = RequestOptions{
+	Type:  "header",
+	Label: "X-EARLY-ACCESS",
+	Value: "incident-workflows-early-access",
+}
+
+// ListIncidentWorkflowOptions represents options when retrieving a list of incident workflows.
+type ListIncidentWorkflowOptions struct {
+	Offset   int      `url:"offset,omitempty"`
+	Limit    int      `url:"limit,omitempty"`
+	Total    bool     `url:"total,omitempty"`
+	Includes []string `url:"include,brackets,omitempty"`
+}
+
+type listIncidentWorkflowOptionsGen struct {
+	options *ListIncidentWorkflowOptions
+}
+
+func (o *listIncidentWorkflowOptionsGen) currentOffset() int {
+	return o.options.Offset
+}
+
+func (o *listIncidentWorkflowOptionsGen) changeOffset(i int) {
+	o.options.Offset = i
+}
+
+func (o *listIncidentWorkflowOptionsGen) buildStruct() interface{} {
+	return o.options
+}
+
+// List lists existing incident workflows. If a non-zero Limit is passed as an option, only a single page of results will be
+// returned. Otherwise, the entire list of incident workflows will be returned.
+func (s *IncidentWorkflowService) List(o *ListIncidentWorkflowOptions) (*ListIncidentWorkflowResponse, *Response, error) {
+	return s.ListContext(context.Background(), o)
+}
+
+// ListContext lists existing incident workflows. If a non-zero Limit is passed as an option, only a single page of results will be
+// returned. Otherwise, the entire list of incident workflows will be returned.
+func (s *IncidentWorkflowService) ListContext(ctx context.Context, o *ListIncidentWorkflowOptions) (*ListIncidentWorkflowResponse, *Response, error) {
+	u := "/incident_workflows"
+	v := new(ListIncidentWorkflowResponse)
+
+	if o == nil {
+		o = &ListIncidentWorkflowOptions{}
+	}
+
+	if o.Limit != 0 {
+		resp, err := s.client.newRequestDoOptionsContext(ctx, "GET", u, o, nil, &v, incidentWorkflowsEarlyAccessHeader)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		return v, resp, nil
+	} else {
+		workflows := make([]*IncidentWorkflow, 0)
+
+		// Create a handler closure capable of parsing data from the workflows endpoint
+		// and appending resultant response plays to the return slice.
+		responseHandler := func(response *Response) (ListResp, *Response, error) {
+			var result ListIncidentWorkflowResponse
+
+			if err := s.client.DecodeJSON(response, &result); err != nil {
+				return ListResp{}, response, err
+			}
+
+			workflows = append(workflows, result.IncidentWorkflows...)
+
+			// Return stats on the current page. Caller can use this information to
+			// adjust for requesting additional pages.
+			return ListResp{
+				More:   result.More,
+				Offset: result.Offset,
+				Limit:  result.Limit,
+			}, response, nil
+		}
+		err := s.client.newRequestPagedGetQueryDoContext(ctx, u, responseHandler, &listIncidentWorkflowOptionsGen{
+			options: o,
+		}, incidentWorkflowsEarlyAccessHeader)
+		if err != nil {
+			return nil, nil, err
+		}
+		v.IncidentWorkflows = workflows
+
+		return v, nil, nil
+	}
+}
+
+// Get gets an incident workflow.
+func (s *IncidentWorkflowService) Get(id string) (*IncidentWorkflow, *Response, error) {
+	return s.GetContext(context.Background(), id)
+}
+
+// GetContext gets an incident workflow.
+func (s *IncidentWorkflowService) GetContext(ctx context.Context, id string) (*IncidentWorkflow, *Response, error) {
+	u := fmt.Sprintf("/incident_workflows/%s", id)
+	v := new(IncidentWorkflowPayload)
+
+	resp, err := s.client.newRequestDoOptionsContext(ctx, "GET", u, nil, nil, v, incidentWorkflowsEarlyAccessHeader)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v.IncidentWorkflow, resp, nil
+}
+
+// Create creates a new incident workflow.
+func (s *IncidentWorkflowService) Create(iw *IncidentWorkflow) (*IncidentWorkflow, *Response, error) {
+	return s.CreateContext(context.Background(), iw)
+}
+
+// CreateContext creates a new incident workflow.
+func (s *IncidentWorkflowService) CreateContext(ctx context.Context, iw *IncidentWorkflow) (*IncidentWorkflow, *Response, error) {
+	u := "/incident_workflows"
+	v := new(IncidentWorkflowPayload)
+
+	resp, err := s.client.newRequestDoOptionsContext(ctx, "POST", u, nil, &IncidentWorkflowPayload{IncidentWorkflow: iw}, &v, incidentWorkflowsEarlyAccessHeader)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v.IncidentWorkflow, resp, nil
+}
+
+// Delete removes an existing incident workflow.
+func (s *IncidentWorkflowService) Delete(id string) (*Response, error) {
+	return s.DeleteContext(context.Background(), id)
+}
+
+// DeleteContext removes an existing incident workflow.
+func (s *IncidentWorkflowService) DeleteContext(ctx context.Context, id string) (*Response, error) {
+	u := fmt.Sprintf("/incident_workflows/%s", id)
+	return s.client.newRequestDoOptionsContext(ctx, "DELETE", u, nil, nil, nil, incidentWorkflowsEarlyAccessHeader)
+}
+
+// Update updates an existing incident workflow.
+func (s *IncidentWorkflowService) Update(id string, iw *IncidentWorkflow) (*IncidentWorkflow, *Response, error) {
+	return s.UpdateContext(context.Background(), id, iw)
+}
+
+// UpdateContext updates an existing incident workflow.
+func (s *IncidentWorkflowService) UpdateContext(ctx context.Context, id string, iw *IncidentWorkflow) (*IncidentWorkflow, *Response, error) {
+	u := fmt.Sprintf("/incident_workflows/%s", id)
+	v := new(IncidentWorkflowPayload)
+
+	resp, err := s.client.newRequestDoOptionsContext(ctx, "PUT", u, nil, &IncidentWorkflowPayload{IncidentWorkflow: iw}, &v, incidentWorkflowsEarlyAccessHeader)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v.IncidentWorkflow, resp, nil
+}

--- a/pagerduty/incident_workflow_test.go
+++ b/pagerduty/incident_workflow_test.go
@@ -1,0 +1,638 @@
+package pagerduty
+
+import (
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestIncidentWorkflowList(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/incident_workflows", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testQueryMaxCount(t, r, 1)
+		testHeader(t, r, "x-early-access", "incident-workflows-early-access")
+		offset := r.URL.Query().Get("offset")
+
+		switch offset {
+		case "":
+			w.Write([]byte(`{"total": 2, "offset": 0, "more": true, "limit": 1, "incident_workflows":[{"id": "1"}]}`))
+		case "1":
+			w.Write([]byte(`{"total": 2, "offset": 1, "more": false, "limit": 1, "incident_workflows":[{"id": "2"}]}`))
+		default:
+			t.Fatalf("Unexpected offset: %v", offset)
+		}
+
+	})
+
+	resp, _, err := client.IncidentWorkflows.List(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &ListIncidentWorkflowResponse{
+		Total:  0,
+		Offset: 0,
+		More:   false,
+		Limit:  0,
+		IncidentWorkflows: []*IncidentWorkflow{
+			{
+				ID: "1",
+			},
+			{
+				ID: "2",
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(resp, want) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp, want)
+	}
+}
+
+func TestIncidentWorkflowList_SecondPage(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/incident_workflows", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testHeader(t, r, "x-early-access", "incident-workflows-early-access")
+		testQueryCount(t, r, 1)
+		offset := r.URL.Query().Get("offset")
+
+		switch offset {
+		case "1":
+			w.Write([]byte(`{"total": 2, "offset": 1, "more": false, "limit": 1, "incident_workflows":[{"id": "2"}]}`))
+		default:
+			t.Fatalf("Unexpected offset: %v", offset)
+		}
+
+	})
+
+	resp, _, err := client.IncidentWorkflows.List(&ListIncidentWorkflowOptions{Offset: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &ListIncidentWorkflowResponse{
+		Total:  0,
+		Offset: 0,
+		More:   false,
+		Limit:  0,
+		IncidentWorkflows: []*IncidentWorkflow{
+			{
+				ID: "2",
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(resp, want) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp, want)
+	}
+}
+
+func TestIncidentWorkflowList_Limit(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/incident_workflows", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testHeader(t, r, "x-early-access", "incident-workflows-early-access")
+		testQueryCount(t, r, 1)
+		testQueryValue(t, r, "limit", "42")
+
+		w.Write([]byte(`{"total": 1, "offset": 0, "more": false, "limit": 42, "incident_workflows":[{"id": "2"}]}`))
+
+	})
+
+	resp, _, err := client.IncidentWorkflows.List(&ListIncidentWorkflowOptions{Limit: 42})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &ListIncidentWorkflowResponse{
+		Total:  1,
+		Offset: 0,
+		More:   false,
+		Limit:  42,
+		IncidentWorkflows: []*IncidentWorkflow{
+			{
+				ID: "2",
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(resp, want) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp, want)
+	}
+}
+
+func TestIncidentWorkflowList_WithOptions(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/incident_workflows", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testHeader(t, r, "x-early-access", "incident-workflows-early-access")
+
+		testQueryMinCount(t, r, 1)
+		testQueryMaxCount(t, r, 2)
+		testQueryValue(t, r, "include[]", "steps")
+
+		offset := r.URL.Query().Get("offset")
+		switch offset {
+		case "":
+			w.Write([]byte(`{"total": 2, "offset": 0, "more": true, "limit": 1, "incident_workflows":[{"id": "1"}]}`))
+		case "1":
+			w.Write([]byte(`{"total": 2, "offset": 1, "more": false, "limit": 1, "incident_workflows":[{"id": "2"}]}`))
+		default:
+			t.Fatalf("Unexpected offset: %v", offset)
+		}
+
+	})
+
+	resp, _, err := client.IncidentWorkflows.List(&ListIncidentWorkflowOptions{
+		Includes: []string{"steps"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &ListIncidentWorkflowResponse{
+		Total:  0,
+		Offset: 0,
+		More:   false,
+		Limit:  0,
+		IncidentWorkflows: []*IncidentWorkflow{
+			{
+				ID: "1",
+			},
+			{
+				ID: "2",
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(resp, want) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp, want)
+	}
+}
+
+func TestIncidentWorkflowGet(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/incident_workflows/IW1", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testHeader(t, r, "x-early-access", "incident-workflows-early-access")
+		testBody(t, r, "")
+
+		w.Write([]byte(`
+{
+  "incident_workflow": {
+    "id": "TO38234",
+    "type": "incident_workflow",
+    "name": "Example Workflow",
+    "description": "This workflow serves as an example",
+    "self": "https://api.pagerduty.com/incident_workflows/TO38234",
+    "html_url": "https://subdomain.pagerduty.com/flex-workflows/workflows/TO38234/edit",
+    "created_at": "2022-06-07T00:01:55Z",
+    "last_started_at": "2022-06-07T00:01:55Z",
+    "steps": [
+      {
+        "id": "32OIHWEJ",
+        "type": "step",
+        "name": "Example Step",
+        "description": "An example workflow step",
+        "action_configuration": {
+            "action_id": "example/action/v1",
+            "description": "Description of the example action",
+            "inputs": [
+                {
+                    "name": "Example input",
+                    "parameter_type": "text",
+                    "value": "{{ example-value }}"
+                }
+            ],
+            "outputs": [
+                {
+                    "name": "Example output",
+                    "reference_name": "example-output",
+                    "parameter_type": "text"
+                }
+            ]
+        }
+      },
+      {
+        "id": "D3IT0D3",
+        "type": "step",
+        "name": "Subsequent Step",
+        "description": "A subsequent step in this workflow",
+        "action_configuration": {
+            "action_id": "example/action/v1",
+            "description": "Description of the example action",
+            "inputs": [
+                {
+                    "name": "Example input",
+                    "parameter_type": "text",
+                    "value": "{{ example-value }}"
+                }
+            ],
+            "outputs": [
+                {
+                    "name": "Example output",
+                    "reference_name": "example-output",
+                    "parameter_type": "text"
+                }
+            ]
+        }
+      }
+    ]
+  }
+}
+`))
+
+	})
+
+	resp, _, err := client.IncidentWorkflows.Get("IW1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	workflowDesc := "This workflow serves as an example"
+	firstStepDesc := "An example workflow step"
+	secondStepDesc := "A subsequent step in this workflow"
+	actionDesc := "Description of the example action"
+
+	want := &IncidentWorkflow{
+		ID:          "TO38234",
+		Type:        "incident_workflow",
+		Name:        "Example Workflow",
+		Description: &workflowDesc,
+		Self:        "https://api.pagerduty.com/incident_workflows/TO38234",
+		Steps: []*IncidentWorkflowStep{
+			{
+				ID:          "32OIHWEJ",
+				Type:        "step",
+				Name:        "Example Step",
+				Description: &firstStepDesc,
+				Configuration: &IncidentWorkflowActionConfiguration{
+					ActionID:    "example/action/v1",
+					Description: &actionDesc,
+					Inputs: []*IncidentWorkflowActionInput{
+						{
+							Name:  "Example input",
+							Value: "{{ example-value }}",
+						},
+					},
+				},
+			}, {
+				ID:          "D3IT0D3",
+				Type:        "step",
+				Name:        "Subsequent Step",
+				Description: &secondStepDesc,
+				Configuration: &IncidentWorkflowActionConfiguration{
+					ActionID:    "example/action/v1",
+					Description: &actionDesc,
+					Inputs: []*IncidentWorkflowActionInput{
+						{
+							Name:  "Example input",
+							Value: "{{ example-value }}",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(resp, want) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp, want)
+	}
+}
+
+func TestIncidentWorkflowCreate(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/incident_workflows", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		testHeader(t, r, "x-early-access", "incident-workflows-early-access")
+		testBody(t, r, `{"incident_workflow":{"name":"Example Workflow","description":"This workflow serves as an example","steps":[{"name":"Example Step","description":"An example workflow step","action_configuration":{"action_id":"example/action/v1","inputs":[{"name":"Example input","value":"{{ example-value }}"}]}},{"name":"Subsequent Step","description":"A subsequent step in this workflow","action_configuration":{"action_id":"example/action/v1","inputs":[{"name":"Example input","value":"{{ example-value }}"}]}}]}}`)
+
+		w.Write([]byte(`
+{
+  "incident_workflow": {
+    "id": "TO38234",
+    "type": "incident_workflow",
+    "name": "Example Workflow",
+    "description": "This workflow serves as an example",
+    "self": "https://api.pagerduty.com/incident_workflows/TO38234",
+    "html_url": "https://subdomain.pagerduty.com/flex-workflows/workflows/TO38234/edit",
+    "created_at": "2022-06-07T00:01:55Z",
+    "last_started_at": "2022-06-07T00:01:55Z",
+    "steps": [
+      {
+        "id": "32OIHWEJ",
+        "type": "step",
+        "name": "Example Step",
+        "description": "An example workflow step",
+        "action_configuration": {
+            "action_id": "example/action/v1",
+            "description": "Description of the example action",
+            "inputs": [
+                {
+                    "name": "Example input",
+                    "parameter_type": "text",
+                    "value": "{{ example-value }}"
+                }
+            ],
+            "outputs": [
+                {
+                    "name": "Example output",
+                    "reference_name": "example-output",
+                    "parameter_type": "text"
+                }
+            ]
+        }
+      },
+      {
+        "id": "D3IT0D3",
+        "type": "step",
+        "name": "Subsequent Step",
+        "description": "A subsequent step in this workflow",
+        "action_configuration": {
+            "action_id": "example/action/v1",
+            "description": "Description of the example action",
+            "inputs": [
+                {
+                    "name": "Example input",
+                    "parameter_type": "text",
+                    "value": "{{ example-value }}"
+                }
+            ],
+            "outputs": [
+                {
+                    "name": "Example output",
+                    "reference_name": "example-output",
+                    "parameter_type": "text"
+                }
+            ]
+        }
+      }
+    ]
+  }
+}
+`))
+
+	})
+
+	workflowDesc := "This workflow serves as an example"
+	firstStepDesc := "An example workflow step"
+	secondStepDesc := "A subsequent step in this workflow"
+	actionDesc := "Description of the example action"
+
+	resp, _, err := client.IncidentWorkflows.Create(&IncidentWorkflow{
+		Name:        "Example Workflow",
+		Description: &workflowDesc,
+		Steps: []*IncidentWorkflowStep{
+			{
+				Name:        "Example Step",
+				Description: &firstStepDesc,
+				Configuration: &IncidentWorkflowActionConfiguration{
+					ActionID: "example/action/v1",
+					Inputs: []*IncidentWorkflowActionInput{
+						{
+							Name:  "Example input",
+							Value: "{{ example-value }}",
+						},
+					},
+				},
+			}, {
+				Name:        "Subsequent Step",
+				Description: &secondStepDesc,
+				Configuration: &IncidentWorkflowActionConfiguration{
+					ActionID: "example/action/v1",
+					Inputs: []*IncidentWorkflowActionInput{
+						{
+							Name:  "Example input",
+							Value: "{{ example-value }}",
+						},
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &IncidentWorkflow{
+		ID:          "TO38234",
+		Type:        "incident_workflow",
+		Name:        "Example Workflow",
+		Description: &workflowDesc,
+		Self:        "https://api.pagerduty.com/incident_workflows/TO38234",
+		Steps: []*IncidentWorkflowStep{
+			{
+				ID:          "32OIHWEJ",
+				Type:        "step",
+				Name:        "Example Step",
+				Description: &firstStepDesc,
+				Configuration: &IncidentWorkflowActionConfiguration{
+					ActionID:    "example/action/v1",
+					Description: &actionDesc,
+					Inputs: []*IncidentWorkflowActionInput{
+						{
+							Name:  "Example input",
+							Value: "{{ example-value }}",
+						},
+					},
+				},
+			}, {
+				ID:          "D3IT0D3",
+				Type:        "step",
+				Name:        "Subsequent Step",
+				Description: &secondStepDesc,
+				Configuration: &IncidentWorkflowActionConfiguration{
+					ActionID:    "example/action/v1",
+					Description: &actionDesc,
+					Inputs: []*IncidentWorkflowActionInput{
+						{
+							Name:  "Example input",
+							Value: "{{ example-value }}",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(resp, want) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp, want)
+	}
+}
+
+func TestIncidentWorkflowDelete(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/incident_workflows/IW1", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+		testHeader(t, r, "x-early-access", "incident-workflows-early-access")
+		w.WriteHeader(200)
+	})
+
+	resp, err := client.IncidentWorkflows.Delete("IW1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.Response.StatusCode != 200 {
+		t.Errorf("unexpected response code. want 200. got %v", resp.Response.StatusCode)
+	}
+}
+
+func TestIncidentWorkflowUpdate(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/incident_workflows/IW1", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		testHeader(t, r, "x-early-access", "incident-workflows-early-access")
+		testBody(t, r, `{"incident_workflow":{"description":"Updated description","steps":[{"id":"32OIHWEJ"},{"id":"D3IT0D3","name":"Subsequent Step Updated Name"}]}}`)
+
+		w.Write([]byte(`
+{
+  "incident_workflow": {
+    "id": "TO38234",
+    "type": "incident_workflow",
+    "name": "Example Workflow",
+    "description": "Updated description",
+    "self": "https://api.pagerduty.com/incident_workflows/TO38234",
+    "html_url": "https://subdomain.pagerduty.com/flex-workflows/workflows/TO38234/edit",
+    "created_at": "2022-06-07T00:01:55Z",
+    "last_started_at": "2022-06-07T00:01:55Z",
+    "steps": [
+      {
+        "id": "32OIHWEJ",
+        "type": "step",
+        "name": "Example Step",
+        "description": "An example workflow step",
+        "action_configuration": {
+            "action_id": "example/action/v1",
+            "description": "Description of the example action",
+            "inputs": [
+                {
+                    "name": "Example input",
+                    "parameter_type": "text",
+                    "value": "{{ example-value }}"
+                }
+            ],
+            "outputs": [
+                {
+                    "name": "Example output",
+                    "reference_name": "example-output",
+                    "parameter_type": "text"
+                }
+            ]
+        }
+      },
+      {
+        "id": "D3IT0D3",
+        "type": "step",
+        "name": "Subsequent Step Updated Name",
+        "description": "A subsequent step in this workflow",
+        "action_configuration": {
+            "action_id": "example/action/v1",
+            "description": "Description of the example action",
+            "inputs": [
+                {
+                    "name": "Example input",
+                    "parameter_type": "text",
+                    "value": "{{ example-value }}"
+                }
+            ],
+            "outputs": [
+                {
+                    "name": "Example output",
+                    "reference_name": "example-output",
+                    "parameter_type": "text"
+                }
+            ]
+        }
+      }
+    ]
+  }
+}
+`))
+
+	})
+
+	updatedWorkflowDesc := "Updated description"
+	firstStepDesc := "An example workflow step"
+	secondStepDesc := "A subsequent step in this workflow"
+	actionDesc := "Description of the example action"
+
+	resp, _, err := client.IncidentWorkflows.Update("IW1", &IncidentWorkflow{
+		Description: &updatedWorkflowDesc,
+		Steps: []*IncidentWorkflowStep{
+			{
+				ID: "32OIHWEJ",
+			},
+			{
+				ID:   "D3IT0D3",
+				Name: "Subsequent Step Updated Name",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &IncidentWorkflow{
+		ID:          "TO38234",
+		Type:        "incident_workflow",
+		Name:        "Example Workflow",
+		Description: &updatedWorkflowDesc,
+		Self:        "https://api.pagerduty.com/incident_workflows/TO38234",
+		Steps: []*IncidentWorkflowStep{
+			{
+				ID:          "32OIHWEJ",
+				Type:        "step",
+				Name:        "Example Step",
+				Description: &firstStepDesc,
+				Configuration: &IncidentWorkflowActionConfiguration{
+					ActionID:    "example/action/v1",
+					Description: &actionDesc,
+					Inputs: []*IncidentWorkflowActionInput{
+						{
+							Name:  "Example input",
+							Value: "{{ example-value }}",
+						},
+					},
+				},
+			}, {
+				ID:          "D3IT0D3",
+				Type:        "step",
+				Name:        "Subsequent Step Updated Name",
+				Description: &secondStepDesc,
+				Configuration: &IncidentWorkflowActionConfiguration{
+					ActionID:    "example/action/v1",
+					Description: &actionDesc,
+					Inputs: []*IncidentWorkflowActionInput{
+						{
+							Name:  "Example input",
+							Value: "{{ example-value }}",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(resp, want) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp, want)
+	}
+}

--- a/pagerduty/incident_workflow_trigger.go
+++ b/pagerduty/incident_workflow_trigger.go
@@ -1,0 +1,180 @@
+package pagerduty
+
+import (
+	"context"
+	"fmt"
+)
+
+// IncidentWorkflowTriggerService handles the communication with incident workflow
+// trigger related methods of the PagerDuty API.
+type IncidentWorkflowTriggerService service
+
+// IncidentWorkflowTrigger represents an incident workflow.
+type IncidentWorkflowTrigger struct {
+	ID                      string                      `json:"id,omitempty"`
+	Type                    string                      `json:"type,omitempty"`
+	TriggerType             IncidentWorkflowTriggerType `json:"trigger_type,omitempty"`
+	Workflow                *IncidentWorkflow           `json:"workflow,omitempty"`
+	Services                []*ServiceReference         `json:"services,omitempty"`
+	Condition               *string                     `json:"condition,omitempty"`
+	SubscribedToAllServices bool                        `json:"is_subscribed_to_all_services,omitempty"`
+}
+
+// ListIncidentWorkflowTriggerResponse represents a list response of incident workflow triggers.
+type ListIncidentWorkflowTriggerResponse struct {
+	Triggers      []*IncidentWorkflowTrigger `json:"triggers,omitempty"`
+	NextPageToken string                     `json:"next_page_token,omitempty"`
+	Limit         int                        `json:"limit,omitempty"`
+}
+
+// IncidentWorkflowTriggerPayload represents payload with an incident workflow trigger object.
+type IncidentWorkflowTriggerPayload struct {
+	Trigger *IncidentWorkflowTrigger `json:"trigger,omitempty"`
+}
+
+// ListIncidentWorkflowTriggerOptions represents options when retrieving a list of incident workflow triggers.
+type ListIncidentWorkflowTriggerOptions struct {
+	IncidentID  string                      `url:"incident_id,omitempty"`
+	WorkflowID  string                      `url:"workflow_id,omitempty"`
+	ServiceID   string                      `url:"service_id,omitempty"`
+	TriggerType IncidentWorkflowTriggerType `url:"trigger_type,omitempty"`
+	Limit       int                         `url:"limit,omitempty"`
+	PageToken   string                      `url:"page_token,omitempty"`
+}
+
+type listIncidentWorkflowTriggerOptionsGen struct {
+	options *ListIncidentWorkflowTriggerOptions
+}
+
+func (o *listIncidentWorkflowTriggerOptionsGen) currentCursor() string {
+	return o.options.PageToken
+}
+
+func (o *listIncidentWorkflowTriggerOptionsGen) changeCursor(s string) {
+	o.options.PageToken = s
+}
+
+func (o *listIncidentWorkflowTriggerOptionsGen) buildStruct() interface{} {
+	return o.options
+}
+
+// List lists existing incident workflow triggers. If a non-zero Limit is passed as an option, only a single page of results will be
+// returned. Otherwise, the entire list of incident workflows will be returned.
+func (s *IncidentWorkflowTriggerService) List(o *ListIncidentWorkflowTriggerOptions) (*ListIncidentWorkflowTriggerResponse, *Response, error) {
+	return s.ListContext(context.Background(), o)
+}
+
+// ListContext lists existing incident workflow triggers. If a non-zero Limit is passed as an option, only a single page of results will be
+// returned. Otherwise, the entire list of incident workflows will be returned.
+func (s *IncidentWorkflowTriggerService) ListContext(ctx context.Context, o *ListIncidentWorkflowTriggerOptions) (*ListIncidentWorkflowTriggerResponse, *Response, error) {
+	u := "/incident_workflows/triggers"
+	v := new(ListIncidentWorkflowTriggerResponse)
+
+	if o == nil {
+		o = &ListIncidentWorkflowTriggerOptions{}
+	}
+
+	if o.Limit != 0 {
+		resp, err := s.client.newRequestDoOptionsContext(ctx, "GET", u, o, nil, &v, incidentWorkflowsEarlyAccessHeader)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		return v, resp, nil
+	} else {
+		triggers := make([]*IncidentWorkflowTrigger, 0)
+
+		// Create a handler closure capable of parsing data from the workflows endpoint
+		// and appending resultant response plays to the return slice.
+		responseHandler := func(response *Response) (CursorListResp, *Response, error) {
+			var result ListIncidentWorkflowTriggerResponse
+
+			if err := s.client.DecodeJSON(response, &result); err != nil {
+				return CursorListResp{}, response, err
+			}
+
+			triggers = append(triggers, result.Triggers...)
+
+			// Return stats on the current page. Caller can use this information to
+			// adjust for requesting additional pages.
+			return CursorListResp{
+				Limit:      result.Limit,
+				NextCursor: result.NextPageToken,
+			}, response, nil
+		}
+		err := s.client.newRequestCursorPagedGetQueryDoContext(ctx, u, responseHandler, &listIncidentWorkflowTriggerOptionsGen{
+			options: o,
+		}, incidentWorkflowsEarlyAccessHeader)
+		if err != nil {
+			return nil, nil, err
+		}
+		v.Triggers = triggers
+
+		return v, nil, nil
+	}
+}
+
+// Get gets an incident workflow trigger.
+func (s *IncidentWorkflowTriggerService) Get(id string) (*IncidentWorkflowTrigger, *Response, error) {
+	return s.GetContext(context.Background(), id)
+}
+
+// GetContext gets an incident workflow trigger.
+func (s *IncidentWorkflowTriggerService) GetContext(ctx context.Context, id string) (*IncidentWorkflowTrigger, *Response, error) {
+	u := fmt.Sprintf("/incident_workflows/triggers/%s", id)
+	v := new(IncidentWorkflowTriggerPayload)
+
+	resp, err := s.client.newRequestDoOptionsContext(ctx, "GET", u, nil, nil, v, incidentWorkflowsEarlyAccessHeader)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v.Trigger, resp, nil
+}
+
+// Create creates a new incident workflow trigger.
+func (s *IncidentWorkflowTriggerService) Create(t *IncidentWorkflowTrigger) (*IncidentWorkflowTrigger, *Response, error) {
+	return s.CreateContext(context.Background(), t)
+}
+
+// CreateContext creates a new incident workflow trigger.
+func (s *IncidentWorkflowTriggerService) CreateContext(ctx context.Context, t *IncidentWorkflowTrigger) (*IncidentWorkflowTrigger, *Response, error) {
+	u := "/incident_workflows/triggers"
+	v := new(IncidentWorkflowTriggerPayload)
+
+	resp, err := s.client.newRequestDoOptionsContext(ctx, "POST", u, nil, &t, &v, incidentWorkflowsEarlyAccessHeader)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v.Trigger, resp, nil
+}
+
+// Delete removes an existing incident workflow trigger.
+func (s *IncidentWorkflowTriggerService) Delete(id string) (*Response, error) {
+	return s.DeleteContext(context.Background(), id)
+}
+
+// DeleteContext removes an existing incident workflow trigger.
+func (s *IncidentWorkflowTriggerService) DeleteContext(ctx context.Context, id string) (*Response, error) {
+	u := fmt.Sprintf("/incident_workflows/triggers/%s", id)
+	return s.client.newRequestDoOptionsContext(ctx, "DELETE", u, nil, nil, nil, incidentWorkflowsEarlyAccessHeader)
+}
+
+// Update updates an existing incident workflow trigger.
+func (s *IncidentWorkflowTriggerService) Update(id string, t *IncidentWorkflowTrigger) (*IncidentWorkflowTrigger, *Response, error) {
+	return s.UpdateContext(context.Background(), id, t)
+}
+
+// UpdateContext updates an existing incident workflow trigger.
+func (s *IncidentWorkflowTriggerService) UpdateContext(ctx context.Context, id string, t *IncidentWorkflowTrigger) (*IncidentWorkflowTrigger, *Response, error) {
+	u := fmt.Sprintf("/incident_workflows/triggers/%s", id)
+	v := new(IncidentWorkflowTriggerPayload)
+
+	resp, err := s.client.newRequestDoOptionsContext(ctx, "PUT", u, nil, &t, &v, incidentWorkflowsEarlyAccessHeader)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v.Trigger, resp, nil
+}

--- a/pagerduty/incident_workflow_trigger_test.go
+++ b/pagerduty/incident_workflow_trigger_test.go
@@ -1,0 +1,463 @@
+package pagerduty
+
+import (
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestIncidentWorkflowTriggerList(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/incident_workflows/triggers", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testHeader(t, r, "x-early-access", "incident-workflows-early-access")
+		testQueryMaxCount(t, r, 1)
+		pageToken := r.URL.Query().Get("page_token")
+
+		switch pageToken {
+		case "":
+			w.Write([]byte(`{"next_page_token":"abc", "triggers":[{"id": "1"}]}`))
+		case "abc":
+			w.Write([]byte(`{"next_page_token":"def", "triggers":[{"id": "2"}]}`))
+		case "def":
+			w.Write([]byte(`{"next_page_token":null, "triggers":[{"id": "3"}]}`))
+		default:
+			t.Fatalf("Unexpected pageToken: %v", pageToken)
+		}
+
+	})
+
+	resp, _, err := client.IncidentWorkflowTriggers.List(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &ListIncidentWorkflowTriggerResponse{
+		Limit: 0,
+		Triggers: []*IncidentWorkflowTrigger{
+			{
+				ID: "1",
+			},
+			{
+				ID: "2",
+			},
+			{
+				ID: "3",
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(resp, want) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp, want)
+	}
+}
+
+func TestIncidentWorkflowTriggerList_SecondPage(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/incident_workflows/triggers", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testHeader(t, r, "x-early-access", "incident-workflows-early-access")
+		testQueryCount(t, r, 1)
+		pageToken := r.URL.Query().Get("page_token")
+
+		switch pageToken {
+		case "def":
+			w.Write([]byte(`{"next_page_token":null, "triggers":[{"id": "3"}]}`))
+		default:
+			t.Fatalf("Unexpected pageToken: %v", pageToken)
+		}
+
+	})
+
+	resp, _, err := client.IncidentWorkflowTriggers.List(&ListIncidentWorkflowTriggerOptions{PageToken: "def"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &ListIncidentWorkflowTriggerResponse{
+		Limit: 0,
+		Triggers: []*IncidentWorkflowTrigger{
+			{
+				ID: "3",
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(resp, want) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp, want)
+	}
+}
+
+func TestIncidentWorkflowTriggerList_Limit(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/incident_workflows/triggers", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testHeader(t, r, "x-early-access", "incident-workflows-early-access")
+		testQueryCount(t, r, 1)
+		testQueryValue(t, r, "limit", "42")
+
+		w.Write([]byte(`{"limit": 42, "triggers":[{"id": "2"}]}`))
+
+	})
+
+	resp, _, err := client.IncidentWorkflowTriggers.List(&ListIncidentWorkflowTriggerOptions{Limit: 42})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &ListIncidentWorkflowTriggerResponse{
+		Limit: 42,
+		Triggers: []*IncidentWorkflowTrigger{
+			{
+				ID: "2",
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(resp, want) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp, want)
+	}
+}
+
+func TestIncidentWorkflowTriggerList_WithOptions(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/incident_workflows/triggers", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testHeader(t, r, "x-early-access", "incident-workflows-early-access")
+
+		testQueryMinCount(t, r, 1)
+		testQueryMaxCount(t, r, 2)
+		testQueryValue(t, r, "trigger_type", "manual")
+
+		pageToken := r.URL.Query().Get("page_token")
+		switch pageToken {
+		case "":
+			w.Write([]byte(`{"next_page_token":"abc", "triggers":[{"id": "1"}]}`))
+		case "abc":
+			w.Write([]byte(`{"triggers":[{"id": "2"}]}`))
+		default:
+			t.Fatalf("Unexpected pageToken: %v", pageToken)
+		}
+
+	})
+
+	resp, _, err := client.IncidentWorkflowTriggers.List(&ListIncidentWorkflowTriggerOptions{
+		TriggerType: IncidentWorkflowTriggerTypeManual,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &ListIncidentWorkflowTriggerResponse{
+		Triggers: []*IncidentWorkflowTrigger{
+			{
+				ID: "1",
+			},
+			{
+				ID: "2",
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(resp, want) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp, want)
+	}
+}
+
+func TestIncidentWorkflowTriggerGet(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/incident_workflows/triggers/IWT1", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testHeader(t, r, "x-early-access", "incident-workflows-early-access")
+		testBody(t, r, "")
+
+		w.Write([]byte(`
+{
+   "trigger":{
+      "id":"abc-123",
+      "type":"workflow_trigger",
+      "trigger_type_name":"Manual Incident Trigger",
+      "trigger_type":"manual",
+      "trigger_url":"https://api.pagerduty.com/incident_workflows/triggers/abc-123/start",
+      "self":"https://api.pagerduty.com/incident_workflows/triggers/abc-123",
+      "workflow":{
+         "id":"TO38234",
+         "type":"workflow",
+         "name":"Example Workflow",
+         "description":"This workflow serves as an example",
+         "self":"https://api.pagerduty.com/incident_workflows/TO38234",
+         "created_at":"2022-06-07T00:01:55Z"
+      },
+      "services":[
+         {
+            "id":"PIJ90N7",
+            "summary":"My Application Service",
+            "type":"service",
+            "self":"https://api.pagerduty.com/services/PIJ90N7",
+            "html_url":"https://subdomain.pagerduty.com/services/PIJ90N7",
+            "name":"My Application Service",
+            "created_at":"2015-11-06T11:12:51-05:00",
+            "status":"active"
+         }
+      ],
+      "condition":"incident.priority matches 'P1'",
+      "permissions":{
+         "restricted":true,
+         "team_id":"PDEJ7MP"
+      }
+   }
+}
+`))
+
+	})
+
+	resp, _, err := client.IncidentWorkflowTriggers.Get("IWT1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	workflowDesc := "This workflow serves as an example"
+	cond := "incident.priority matches 'P1'"
+
+	want := &IncidentWorkflowTrigger{
+		ID:          "abc-123",
+		Type:        "workflow_trigger",
+		TriggerType: IncidentWorkflowTriggerTypeManual,
+		Workflow: &IncidentWorkflow{
+			ID:          "TO38234",
+			Type:        "workflow",
+			Name:        "Example Workflow",
+			Description: &workflowDesc,
+			Self:        "https://api.pagerduty.com/incident_workflows/TO38234",
+		},
+		Services: []*ServiceReference{
+			{
+				ID:      "PIJ90N7",
+				Summary: "My Application Service",
+				Type:    "service",
+				Self:    "https://api.pagerduty.com/services/PIJ90N7",
+				HTMLURL: "https://subdomain.pagerduty.com/services/PIJ90N7",
+			},
+		},
+		Condition: &cond,
+	}
+
+	if !reflect.DeepEqual(resp, want) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp, want)
+	}
+}
+
+func TestIncidentWorkflowTriggerCreate(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/incident_workflows/triggers", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		testHeader(t, r, "x-early-access", "incident-workflows-early-access")
+		testBody(t, r, `{"trigger_type":"manual","workflow":{"id":"TO38234"},"services":[{"id":"PIJ90N7"}],"condition":"incident.priority matches 'P1'"}`)
+
+		w.Write([]byte(`
+{
+   "trigger":{
+      "id":"abc-123",
+      "type":"workflow_trigger",
+      "trigger_type_name":"Manual Incident Trigger",
+      "trigger_type":"manual",
+      "trigger_url":"https://api.pagerduty.com/incident_workflows/triggers/abc-123/start",
+      "self":"https://api.pagerduty.com/incident_workflows/triggers/abc-123",
+      "workflow":{
+         "id":"TO38234",
+         "type":"workflow",
+         "name":"Example Workflow",
+         "description":"This workflow serves as an example",
+         "self":"https://api.pagerduty.com/incident_workflows/TO38234",
+         "created_at":"2022-06-07T00:01:55Z"
+      },
+      "services":[
+         {
+            "id":"PIJ90N7",
+            "summary":"My Application Service",
+            "type":"service",
+            "self":"https://api.pagerduty.com/services/PIJ90N7",
+            "html_url":"https://subdomain.pagerduty.com/services/PIJ90N7",
+            "name":"My Application Service",
+            "created_at":"2015-11-06T11:12:51-05:00",
+            "status":"active"
+         }
+      ],
+      "is_subscribed_to_all_services": true,
+      "condition":"incident.priority matches 'P1'"
+   }
+}
+`))
+
+	})
+
+	cond := "incident.priority matches 'P1'"
+
+	resp, _, err := client.IncidentWorkflowTriggers.Create(&IncidentWorkflowTrigger{
+		TriggerType: IncidentWorkflowTriggerTypeManual,
+		Workflow: &IncidentWorkflow{
+			ID: "TO38234",
+		},
+		Services: []*ServiceReference{
+			{
+				ID: "PIJ90N7",
+			},
+		},
+		Condition: &cond,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	workflowDesc := "This workflow serves as an example"
+
+	want := &IncidentWorkflowTrigger{
+		ID:          "abc-123",
+		Type:        "workflow_trigger",
+		TriggerType: IncidentWorkflowTriggerTypeManual,
+		Workflow: &IncidentWorkflow{
+			ID:          "TO38234",
+			Type:        "workflow",
+			Name:        "Example Workflow",
+			Description: &workflowDesc,
+			Self:        "https://api.pagerduty.com/incident_workflows/TO38234",
+		},
+		Services: []*ServiceReference{
+			{
+				ID:      "PIJ90N7",
+				Summary: "My Application Service",
+				Type:    "service",
+				Self:    "https://api.pagerduty.com/services/PIJ90N7",
+				HTMLURL: "https://subdomain.pagerduty.com/services/PIJ90N7",
+			},
+		},
+		SubscribedToAllServices: true,
+		Condition:               &cond,
+	}
+
+	if !reflect.DeepEqual(resp, want) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp, want)
+	}
+}
+
+func TestIncidentWorkflowTriggerDelete(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/incident_workflows/triggers/IWT1", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+		testHeader(t, r, "x-early-access", "incident-workflows-early-access")
+		w.WriteHeader(200)
+	})
+
+	resp, err := client.IncidentWorkflowTriggers.Delete("IWT1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.Response.StatusCode != 200 {
+		t.Errorf("unexpected response code. want 200. got %v", resp.Response.StatusCode)
+	}
+}
+
+func TestIncidentWorkflowTriggerUpdate(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/incident_workflows/triggers/IW1", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		testHeader(t, r, "x-early-access", "incident-workflows-early-access")
+		testBody(t, r, `{"services":[{"id":"PIJ90N7"}],"condition":"incident.priority matches 'P1'"}`)
+
+		w.Write([]byte(`
+{
+   "trigger":{
+      "id":"abc-123",
+      "type":"workflow_trigger",
+      "trigger_type_name":"Manual Incident Trigger",
+      "trigger_type":"manual",
+      "trigger_url":"https://api.pagerduty.com/incident_workflows/triggers/abc-123/start",
+      "self":"https://api.pagerduty.com/incident_workflows/triggers/abc-123",
+      "workflow":{
+         "id":"TO38234",
+         "type":"workflow",
+         "name":"Example Workflow",
+         "description":"This workflow serves as an example",
+         "self":"https://api.pagerduty.com/incident_workflows/TO38234",
+         "created_at":"2022-06-07T00:01:55Z"
+      },
+      "workflow_id":"xyz-123",
+      "workflow_name":"High Priority Incident",
+      "services":[
+         {
+            "id":"PIJ90N7",
+            "summary":"My Application Service",
+            "type":"service",
+            "self":"https://api.pagerduty.com/services/PIJ90N7",
+            "html_url":"https://subdomain.pagerduty.com/services/PIJ90N7",
+            "name":"My Application Service",
+            "created_at":"2015-11-06T11:12:51-05:00",
+            "status":"active"
+         }
+      ],
+      "condition":"incident.priority matches 'P1'"
+   }
+}
+`))
+
+	})
+
+	workflowDesc := "This workflow serves as an example"
+	cond := "incident.priority matches 'P1'"
+
+	resp, _, err := client.IncidentWorkflowTriggers.Update("IW1", &IncidentWorkflowTrigger{
+		Condition: &cond,
+		Services: []*ServiceReference{
+			{
+				ID: "PIJ90N7",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &IncidentWorkflowTrigger{
+		ID:          "abc-123",
+		Type:        "workflow_trigger",
+		TriggerType: IncidentWorkflowTriggerTypeManual,
+		Workflow: &IncidentWorkflow{
+			ID:          "TO38234",
+			Type:        "workflow",
+			Name:        "Example Workflow",
+			Description: &workflowDesc,
+			Self:        "https://api.pagerduty.com/incident_workflows/TO38234",
+		},
+		Services: []*ServiceReference{
+			{
+				ID:      "PIJ90N7",
+				Summary: "My Application Service",
+				Type:    "service",
+				Self:    "https://api.pagerduty.com/services/PIJ90N7",
+				HTMLURL: "https://subdomain.pagerduty.com/services/PIJ90N7",
+			},
+		},
+		Condition: &cond,
+	}
+
+	if !reflect.DeepEqual(resp, want) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp, want)
+	}
+}

--- a/pagerduty/incident_workflow_trigger_type.go
+++ b/pagerduty/incident_workflow_trigger_type.go
@@ -1,0 +1,55 @@
+package pagerduty
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+// IncidentWorkflowTriggerType is an enumeration of available types for incident workflow triggers.
+type IncidentWorkflowTriggerType int64
+
+const (
+	IncidentWorkflowTriggerTypeUnknown IncidentWorkflowTriggerType = iota
+	IncidentWorkflowTriggerTypeManual
+	IncidentWorkflowTriggerTypeConditional
+)
+
+func (d IncidentWorkflowTriggerType) String() string {
+	return incidentWorkflowTriggerTypeToString[d]
+}
+
+func IncidentWorkflowTriggerTypeFromString(s string) IncidentWorkflowTriggerType {
+	return incidentWorkflowTriggerTypeFromString[s]
+}
+
+var incidentWorkflowTriggerTypeToString = map[IncidentWorkflowTriggerType]string{
+	IncidentWorkflowTriggerTypeUnknown:     "unknown",
+	IncidentWorkflowTriggerTypeManual:      "manual",
+	IncidentWorkflowTriggerTypeConditional: "conditional",
+}
+
+var incidentWorkflowTriggerTypeFromString = map[string]IncidentWorkflowTriggerType{
+	"unknown":     IncidentWorkflowTriggerTypeUnknown,
+	"manual":      IncidentWorkflowTriggerTypeManual,
+	"conditional": IncidentWorkflowTriggerTypeConditional,
+}
+
+func (t IncidentWorkflowTriggerType) MarshalJSON() ([]byte, error) {
+	buffer := bytes.NewBufferString(fmt.Sprintf(`"%v"`, t.String()))
+	return buffer.Bytes(), nil
+}
+
+func (t *IncidentWorkflowTriggerType) UnmarshalJSON(data []byte) error {
+	var str string
+	err := json.Unmarshal(data, &str)
+	if err != nil {
+		return err
+	}
+	*t = IncidentWorkflowTriggerTypeFromString(str)
+	return nil
+}
+
+func (t *IncidentWorkflowTriggerType) IsKnown() bool {
+	return *t != IncidentWorkflowTriggerTypeUnknown
+}

--- a/pagerduty/incident_workflow_trigger_type_test.go
+++ b/pagerduty/incident_workflow_trigger_type_test.go
@@ -1,0 +1,58 @@
+package pagerduty
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+)
+
+func TestIncidentWorkflowTriggerTypeIsKnown(t *testing.T) {
+	for k, v := range incidentWorkflowTriggerTypeToString {
+		if v == "unknown" {
+			if k.IsKnown() {
+				t.Errorf("'unknown' data type should not be known")
+			}
+		} else if !k.IsKnown() {
+			t.Errorf("'%s' data type should be known", v)
+		}
+	}
+}
+
+type incidentWorkflowTriggerTypeWrapper struct {
+	Type IncidentWorkflowTriggerType `json:"trigger_type"`
+}
+
+func TestIncidentWorkflowTriggerTypeMarshalJSON(t *testing.T) {
+	for k, v := range incidentWorkflowTriggerTypeToString {
+		o := incidentWorkflowTriggerTypeWrapper{Type: k}
+		b, _ := json.Marshal(o)
+		s := string(b)
+		exp := fmt.Sprintf(`{"trigger_type":"%s"}`, v)
+		if s != exp {
+			t.Errorf(`%s was not marshalled correctly. want:\n%s\ngot:\n%s`, v, exp, s)
+		}
+	}
+}
+
+func TestIncidentWorkflowTriggerTypeUnmarshalJSON(t *testing.T) {
+	for k, v := range incidentWorkflowTriggerTypeToString {
+		js := fmt.Sprintf(`{"trigger_type":"%s"}`, v)
+		var o incidentWorkflowTriggerTypeWrapper
+		err := json.Unmarshal([]byte(js), &o)
+		if err != nil {
+			t.Errorf("Error when unmarhsalling %s", js)
+		}
+		if o.Type != k {
+			t.Errorf(`%s was not unmarshalled correctly. want:\n%s\ngot:\n%s`, js, k, o.Type)
+		}
+	}
+}
+
+func TestIncidentWorkflowTriggerTypeUnmarshalJSON_Error(t *testing.T) {
+	js := `{"trigger_type":1234}`
+	var o incidentWorkflowTriggerTypeWrapper
+	err := json.Unmarshal([]byte(js), &o)
+	if err == nil {
+		t.Errorf("Unmarshalling %s should have produced an error, but didn't.", js)
+	}
+}

--- a/pagerduty/pagerduty_test.go
+++ b/pagerduty/pagerduty_test.go
@@ -1,8 +1,10 @@
 package pagerduty
 
 import (
+	"bytes"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -30,5 +32,49 @@ func teardown() {
 func testMethod(t *testing.T, r *http.Request, want string) {
 	if got := r.Method; got != want {
 		t.Errorf("Request method: %v, want %v", got, want)
+	}
+}
+
+func testHeader(t *testing.T, r *http.Request, key, value string) {
+	v := r.Header.Get(key)
+	if value != v {
+		t.Errorf("unexpected header for key %s.\n\n%s want\n\n%s", key, v, value)
+	}
+}
+
+func testBody(t *testing.T, r *http.Request, expectedBody string) {
+	b := new(bytes.Buffer)
+	b.ReadFrom(r.Body)
+	bodyStr := strings.TrimSpace(b.String())
+	if bodyStr != expectedBody {
+		t.Errorf("unexpected body.\n\n%v want\n\n%v", bodyStr, expectedBody)
+	}
+}
+
+func testQueryValue(t *testing.T, r *http.Request, wantKey string, wantValue string) {
+	if wantValue == "" {
+		if r.URL.Query().Get(wantKey) == "" {
+			t.Errorf("Request missing query param: %v, was %v", wantKey, r.URL.Query().Encode())
+		} else if got := r.URL.Query().Get(wantKey); got != wantValue {
+			t.Errorf("Request unexpected query param value for %v: %v, want %v", wantKey, wantValue, got)
+		}
+	}
+}
+
+func testQueryMinCount(t *testing.T, r *http.Request, minCount int) {
+	if l := len(r.URL.Query()); l < minCount {
+		t.Errorf("Request contained unexpected number of query params: %v, want at least %v", l, minCount)
+	}
+}
+
+func testQueryMaxCount(t *testing.T, r *http.Request, maxCount int) {
+	if l := len(r.URL.Query()); l > maxCount {
+		t.Errorf("Request contained unexpected number of query params: %v, want at most %v", l, maxCount)
+	}
+}
+
+func testQueryCount(t *testing.T, r *http.Request, count int) {
+	if l := len(r.URL.Query()); l != count {
+		t.Errorf("Request contained unexpected number of query params: %v, want exactly %v", l, count)
 	}
 }


### PR DESCRIPTION
A few notes on the scope of this:
* As far as I can tell, this is the first API used in the go client which uses cursor-based pagination so I had to add some new functions in pagerduty.go to handle that differently from offset pagination.
* In order to avoid using deprecated APIs in the new resource and data sources added to the Terraform provider in https://github.com/PagerDuty/terraform-provider-pagerduty/pull/596, I added new functions for the API operations which accept a `context.Context` argument and pass it through the stack. For backwards-compatibility, the old functions are left in place and use `context.Background()` (which is what is already happening, just not explicitly).
* I also added some new test helper functions for the body, header and query string because I wanted to ensure those were tested properly in this new code.