### PR TITLE
[ORCA-3828] Return warnings in the Orchestration Path Update endpoint

### DIFF
--- a/pagerduty/event_orchestration_path.go
+++ b/pagerduty/event_orchestration_path.go
@@ -97,8 +97,17 @@ type EventOrchestrationPathCatchAll struct {
 	Actions *EventOrchestrationPathRuleActions `json:"actions,omitempty"`
 }
 
+type EventOrchestrationPathWarning struct {
+	Feature string `json:"feature"`
+	FeatureType string `json:"feature_type"`
+	Message string `json:"message"`
+	RuleId string `json:"rule_id"`
+	WarningType string `json:"warning_type"`
+}
+
 type EventOrchestrationPathPayload struct {
 	OrchestrationPath *EventOrchestrationPath `json:"orchestration_path,omitempty"`
+	Warnings []*EventOrchestrationPathWarning `json:"warnings"`
 }
 
 const PathTypeRouter string = "router"
@@ -133,7 +142,7 @@ func (s *EventOrchestrationPathService) Get(id string, pathType string) (*EventO
 }
 
 // Update for EventOrchestrationPath
-func (s *EventOrchestrationPathService) Update(id string, pathType string, orchestration_path *EventOrchestrationPath) (*EventOrchestrationPath, *Response, error) {
+func (s *EventOrchestrationPathService) Update(id string, pathType string, orchestration_path *EventOrchestrationPath) (*EventOrchestrationPathPayload, *Response, error) {
 	u := orchestrationPathUrlBuilder(id, pathType)
 	v := new(EventOrchestrationPathPayload)
 	p := EventOrchestrationPathPayload{OrchestrationPath: orchestration_path}
@@ -143,5 +152,5 @@ func (s *EventOrchestrationPathService) Update(id string, pathType string, orche
 		return nil, nil, err
 	}
 
-	return v.OrchestrationPath, resp, nil
+	return v, resp, nil
 }

--- a/pagerduty/event_orchestration_path_test.go
+++ b/pagerduty/event_orchestration_path_test.go
@@ -172,34 +172,37 @@ func TestEventOrchestrationPathRouterPathUpdate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	want := &EventOrchestrationPath{
-		Type: "router",
-		Parent: &EventOrchestrationPathReference{
-			ID:   "E-ORC-1",
-			Self: "https://api.pagerduty.com/event_orchestrations/E-ORC-1",
-			Type: "event_orchestration_reference",
-		},
-		Sets: []*EventOrchestrationPathSet{
-			{
-				ID: "start",
-				Rules: []*EventOrchestrationPathRule{
-					{
-						Actions: &EventOrchestrationPathRuleActions{
-							RouteTo: "P3ZQXDF",
-						},
-						Conditions: []*EventOrchestrationPathRuleCondition{
-							{
-								Expression: "event.summary matches part 'orca'",
+	want := &EventOrchestrationPathPayload{
+		OrchestrationPath: &EventOrchestrationPath{
+			Type: "router",
+			Parent: &EventOrchestrationPathReference{
+				ID:   "E-ORC-1",
+				Self: "https://api.pagerduty.com/event_orchestrations/E-ORC-1",
+				Type: "event_orchestration_reference",
+			},
+			Sets: []*EventOrchestrationPathSet{
+				{
+					ID: "start",
+					Rules: []*EventOrchestrationPathRule{
+						{
+							Actions: &EventOrchestrationPathRuleActions{
+								RouteTo: "P3ZQXDF",
 							},
-							{
-								Expression: "event.summary matches part 'humpback'",
+							Conditions: []*EventOrchestrationPathRuleCondition{
+								{
+									Expression: "event.summary matches part 'orca'",
+								},
+								{
+									Expression: "event.summary matches part 'humpback'",
+								},
 							},
+							ID: "E-ORC-RULE-1",
 						},
-						ID: "E-ORC-RULE-1",
 					},
 				},
 			},
 		},
+		Warnings: nil,
 	}
 
 	if !reflect.DeepEqual(resp, want) {
@@ -234,7 +237,13 @@ func TestEventOrchestrationPathUnroutedPathUpdate(t *testing.T) {
 		if !reflect.DeepEqual(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
-		w.Write([]byte(`{"orchestration_path": { "type": "unrouted", "parent": { "id": "E-ORC-1", "self": "https://api.pagerduty.com/event_orchestrations/E-ORC-1", "type": "event_orchestration_reference" }, "sets": [ { "id": "start", "rules": [ { "actions": { "route_to": "P3ZQXDF" }, "conditions": [ { "expression": "event.summary matches part 'orca'" }, { "expression": "event.summary matches part 'humpback'" } ], "id": "E-ORC-RULE-1"}]}]}}`))
+		w.Write([]byte(`{
+			"orchestration_path": { "type": "unrouted", "parent": { "id": "E-ORC-1", "self": "https://api.pagerduty.com/event_orchestrations/E-ORC-1", "type": "event_orchestration_reference" }, "sets": [ { "id": "start", "rules": [ { "actions": { "route_to": "P3ZQXDF" }, "conditions": [ { "expression": "event.summary matches part 'orca'" }, { "expression": "event.summary matches part 'humpback'" } ], "id": "E-ORC-RULE-1"}]}]},
+			"warnings": [
+				{"feature": "variables", "feature_type": "actions", "message": "Message 1", "rule_id": "abcd001", "warning_type": "forbidden_feature"},
+				{"feature": "extractions", "feature_type": "actions", "message": "Message 2", "rule_id": "abcd002", "warning_type": "forbidden_feature"}
+			]
+		}`))
 	})
 
 	resp, _, err := client.EventOrchestrationPaths.Update("E-ORC-1", PathTypeUnrouted, input)
@@ -242,32 +251,50 @@ func TestEventOrchestrationPathUnroutedPathUpdate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	want := &EventOrchestrationPath{
-		Type: "unrouted",
-		Parent: &EventOrchestrationPathReference{
-			ID:   "E-ORC-1",
-			Self: "https://api.pagerduty.com/event_orchestrations/E-ORC-1",
-			Type: "event_orchestration_reference",
-		},
-		Sets: []*EventOrchestrationPathSet{
-			{
-				ID: "start",
-				Rules: []*EventOrchestrationPathRule{
-					{
-						Actions: &EventOrchestrationPathRuleActions{
-							RouteTo: "P3ZQXDF",
-						},
-						Conditions: []*EventOrchestrationPathRuleCondition{
-							{
-								Expression: "event.summary matches part 'orca'",
+	want := &EventOrchestrationPathPayload{
+		OrchestrationPath: &EventOrchestrationPath{
+			Type: "unrouted",
+			Parent: &EventOrchestrationPathReference{
+				ID:   "E-ORC-1",
+				Self: "https://api.pagerduty.com/event_orchestrations/E-ORC-1",
+				Type: "event_orchestration_reference",
+			},
+			Sets: []*EventOrchestrationPathSet{
+				{
+					ID: "start",
+					Rules: []*EventOrchestrationPathRule{
+						{
+							Actions: &EventOrchestrationPathRuleActions{
+								RouteTo: "P3ZQXDF",
 							},
-							{
-								Expression: "event.summary matches part 'humpback'",
+							Conditions: []*EventOrchestrationPathRuleCondition{
+								{
+									Expression: "event.summary matches part 'orca'",
+								},
+								{
+									Expression: "event.summary matches part 'humpback'",
+								},
 							},
+							ID: "E-ORC-RULE-1",
 						},
-						ID: "E-ORC-RULE-1",
 					},
 				},
+			},
+		},
+		Warnings: []*EventOrchestrationPathWarning{
+			&EventOrchestrationPathWarning{
+				Feature: "variables",
+				FeatureType: "actions",
+				Message: "Message 1",
+				RuleId: "abcd001",
+				WarningType: "forbidden_feature",
+			},
+			&EventOrchestrationPathWarning{
+				Feature: "extractions",
+				FeatureType: "actions",
+				Message: "Message 2",
+				RuleId: "abcd002",
+				WarningType: "forbidden_feature",
 			},
 		},
 	}
@@ -304,7 +331,10 @@ func TestEventOrchestrationPathServicePathUpdate(t *testing.T) {
 		if !reflect.DeepEqual(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
-		w.Write([]byte(`{"orchestration_path": { "type": "service", "parent": { "id": "E-ORC-1", "self": "https://api.pagerduty.com/event_orchestrations/E-ORC-1", "type": "event_orchestration_reference" }, "sets": [ { "id": "start", "rules": [ { "actions": { "route_to": "P3ZQXDF" }, "conditions": [ { "expression": "event.summary matches part 'orca'" }, { "expression": "event.summary matches part 'humpback'" } ], "id": "E-ORC-RULE-1"}]}]}}`))
+		w.Write([]byte(`{
+			"orchestration_path": { "type": "service", "parent": { "id": "E-ORC-1", "self": "https://api.pagerduty.com/event_orchestrations/E-ORC-1", "type": "event_orchestration_reference" }, "sets": [ { "id": "start", "rules": [ { "actions": { "route_to": "P3ZQXDF" }, "conditions": [ { "expression": "event.summary matches part 'orca'" }, { "expression": "event.summary matches part 'humpback'" } ], "id": "E-ORC-RULE-1"}]}]},
+			"warnings": []
+		}`))
 	})
 
 	resp, _, err := client.EventOrchestrationPaths.Update("P3ZQXDF", PathTypeService, input)
@@ -312,34 +342,37 @@ func TestEventOrchestrationPathServicePathUpdate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	want := &EventOrchestrationPath{
-		Type: "service",
-		Parent: &EventOrchestrationPathReference{
-			ID:   "E-ORC-1",
-			Self: "https://api.pagerduty.com/event_orchestrations/E-ORC-1",
-			Type: "event_orchestration_reference",
-		},
-		Sets: []*EventOrchestrationPathSet{
-			{
-				ID: "start",
-				Rules: []*EventOrchestrationPathRule{
-					{
-						Actions: &EventOrchestrationPathRuleActions{
-							RouteTo: "P3ZQXDF",
-						},
-						Conditions: []*EventOrchestrationPathRuleCondition{
-							{
-								Expression: "event.summary matches part 'orca'",
+	want := &EventOrchestrationPathPayload{
+		OrchestrationPath: &EventOrchestrationPath{
+			Type: "service",
+			Parent: &EventOrchestrationPathReference{
+				ID:   "E-ORC-1",
+				Self: "https://api.pagerduty.com/event_orchestrations/E-ORC-1",
+				Type: "event_orchestration_reference",
+			},
+			Sets: []*EventOrchestrationPathSet{
+				{
+					ID: "start",
+					Rules: []*EventOrchestrationPathRule{
+						{
+							Actions: &EventOrchestrationPathRuleActions{
+								RouteTo: "P3ZQXDF",
 							},
-							{
-								Expression: "event.summary matches part 'humpback'",
+							Conditions: []*EventOrchestrationPathRuleCondition{
+								{
+									Expression: "event.summary matches part 'orca'",
+								},
+								{
+									Expression: "event.summary matches part 'humpback'",
+								},
 							},
+							ID: "E-ORC-RULE-1",
 						},
-						ID: "E-ORC-RULE-1",
 					},
 				},
 			},
 		},
+		Warnings: []*EventOrchestrationPathWarning{},
 	}
 
 	if !reflect.DeepEqual(resp, want) {


### PR DESCRIPTION
### Changes
This PR modifies the signature of the Event Orchestration Path Update method to return the entire response instead of just the `orchestration_path` property. The Public API endpoints to update a Router / Unrouted / Service Orchestration has been extended with a `warnings` property that now returns a list of forbidden features that will be skipped during orchestration evaluation. We want to use these warnings in the Provider and display them to the user on `terraform apply`.

### Before Merging
⚠️ These changes break current Provider code and **MUST** be merged in right before https://github.com/PagerDuty/terraform-provider-pagerduty/pull/598