### PR TITLE
Add support for Action Create, Read and Delete

### DIFF
--- a/pagerduty/automation_actions_action.go
+++ b/pagerduty/automation_actions_action.go
@@ -1,0 +1,83 @@
+package pagerduty
+
+import "fmt"
+
+// AutomationActionsAction handles the communication with Automation Actions
+// related methods of the PagerDuty API.
+type AutomationActionsActionService service
+
+type AutomationActionsAction struct {
+	ID                   string                               `json:"id"`
+	Name                 string                               `json:"name"`
+	Description          *string                              `json:"description,omitempty"`
+	ActionType           string                               `json:"action_type"`
+	RunnerID             *string                              `json:"runner,omitempty"`
+	ActionDataReference  AutomationActionsActionDataReference `json:"action_data_reference"`
+	Services             []*ServiceReference                  `json:"services,omitempty"`
+	Teams                []*TeamReference                     `json:"teams,omitempty"`
+	Privileges           *AutomationActionsPrivileges         `json:"privileges,omitempty"`
+	Type                 string                               `json:"type"`
+	ActionClassification *string                              `json:"action_classification,omitempty"`
+	RunnerType           *string                              `json:"runner_type,omitempty"`
+	CreationTime         string                               `json:"creation_time"`
+	ModifyTime           *string                              `json:"modify_time,omitempty"`
+}
+
+type AutomationActionsActionDataReference struct {
+	ProcessAutomationJobId        *string `json:"process_automation_job_id,omitempty"`
+	ProcessAutomationJobArguments *string `json:"process_automation_job_arguments,omitempty"`
+	Script                        *string `json:"script,omitempty"`
+	InvocationCommand             *string `json:"invocation_command,omitempty"`
+}
+
+type AutomationActionsActionPayload struct {
+	Action *AutomationActionsAction `json:"action,omitempty"`
+}
+
+// Create creates a new action
+func (s *AutomationActionsActionService) Create(action *AutomationActionsAction) (*AutomationActionsAction, *Response, error) {
+	u := "/automation_actions/actions"
+	v := new(AutomationActionsActionPayload)
+	o := RequestOptions{
+		Type:  "header",
+		Label: "X-EARLY-ACCESS",
+		Value: "automation-actions-early-access",
+	}
+
+	resp, err := s.client.newRequestDoOptions("POST", u, nil, &AutomationActionsActionPayload{Action: action}, &v, o)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v.Action, resp, nil
+}
+
+// Get retrieves information about an action.
+func (s *AutomationActionsActionService) Get(id string) (*AutomationActionsAction, *Response, error) {
+	u := fmt.Sprintf("/automation_actions/actions/%s", id)
+	v := new(AutomationActionsActionPayload)
+	o := RequestOptions{
+		Type:  "header",
+		Label: "X-EARLY-ACCESS",
+		Value: "automation-actions-early-access",
+	}
+
+	resp, err := s.client.newRequestDoOptions("GET", u, nil, nil, &v, o)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v.Action, resp, nil
+}
+
+// Delete deletes an existing action.
+func (s *AutomationActionsActionService) Delete(id string) (*Response, error) {
+	u := fmt.Sprintf("/automation_actions/actions/%s", id)
+	o := RequestOptions{
+		Type:  "header",
+		Label: "X-EARLY-ACCESS",
+		Value: "automation-actions-early-access",
+	}
+
+	return s.client.newRequestDoOptions("DELETE", u, nil, nil, nil, o)
+}

--- a/pagerduty/automation_actions_action.go
+++ b/pagerduty/automation_actions_action.go
@@ -16,10 +16,10 @@ type AutomationActionsAction struct {
 	Services             []*ServiceReference                  `json:"services,omitempty"`
 	Teams                []*TeamReference                     `json:"teams,omitempty"`
 	Privileges           *AutomationActionsPrivileges         `json:"privileges,omitempty"`
-	Type                 string                               `json:"type"`
+	Type                 *string                              `json:"type,omitempty"`
 	ActionClassification *string                              `json:"action_classification,omitempty"`
 	RunnerType           *string                              `json:"runner_type,omitempty"`
-	CreationTime         string                               `json:"creation_time"`
+	CreationTime         *string                              `json:"creation_time,omitempty"`
 	ModifyTime           *string                              `json:"modify_time,omitempty"`
 }
 

--- a/pagerduty/automation_actions_action_test.go
+++ b/pagerduty/automation_actions_action_test.go
@@ -1,0 +1,165 @@
+package pagerduty
+
+import (
+	"encoding/json"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestAutomationActionsScriptActionGet(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/automation_actions/actions/01DF4OBNYKW84FS9CCYVYS1MOS", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		w.Write([]byte(`{"action":{"action_data_reference":{"script":"java --version","invocation_command":"sh"},"action_type":"script","action_classification":"diagnostic","creation_time":"2022-12-12T18:51:42.048162Z","id":"01DF4OBNYKW84FS9CCYVYS1MOS","name":"Script Action created by TF","type":"action"}}`))
+	})
+
+	resp, _, err := client.AutomationActionsAction.Get("01DF4OBNYKW84FS9CCYVYS1MOS")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	script := "java --version"
+	invocation_command := "sh"
+	classification := "diagnostic"
+	adf := AutomationActionsActionDataReference{
+		Script:            &script,
+		InvocationCommand: &invocation_command,
+	}
+	want := &AutomationActionsAction{
+		ID:                   "01DF4OBNYKW84FS9CCYVYS1MOS",
+		Name:                 "Script Action created by TF",
+		CreationTime:         "2022-12-12T18:51:42.048162Z",
+		ActionType:           "script",
+		Type:                 "action",
+		ActionClassification: &classification,
+		ActionDataReference:  adf,
+	}
+
+	if !reflect.DeepEqual(resp, want) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp, want)
+	}
+}
+
+func TestAutomationActionsProcessAutomationActionGet(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/automation_actions/actions/01DF4OBNYKW84FS9CCYVYS1MOS", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		w.Write([]byte(`{"action":{"action_data_reference":{"process_automation_job_id":"1519578e-a22a-4340-b58f-08194691e10b"},"action_type":"process_automation","creation_time":"2022-12-12T18:51:42.048162Z","id":"01DF4OBNYKW84FS9CCYVYS1MOS","name":"Action created by TF","privileges":{"permissions":["read"]},"type":"action"}}`))
+	})
+
+	resp, _, err := client.AutomationActionsAction.Get("01DF4OBNYKW84FS9CCYVYS1MOS")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	job_id := "1519578e-a22a-4340-b58f-08194691e10b"
+	adf := AutomationActionsActionDataReference{
+		ProcessAutomationJobId: &job_id,
+	}
+	permissions_read := "read"
+	want := &AutomationActionsAction{
+		ID:                  "01DF4OBNYKW84FS9CCYVYS1MOS",
+		Name:                "Action created by TF",
+		CreationTime:        "2022-12-12T18:51:42.048162Z",
+		ActionType:          "process_automation",
+		Type:                "action",
+		ActionDataReference: adf,
+		Privileges: &AutomationActionsPrivileges{
+			Permissions: []*string{&permissions_read},
+		},
+	}
+
+	if !reflect.DeepEqual(resp, want) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp, want)
+	}
+}
+
+func TestAutomationActionsActionCreate(t *testing.T) {
+	setup()
+	defer teardown()
+
+	description := "Description of Action created by TF"
+	runner_id := "01DF4O9T1MDPYOUT7SUX9EXZ4R"
+	adf_arg := "-arg 123"
+	job_id := "1519578e-a22a-4340-b58f-08194691e10b"
+	adf := AutomationActionsActionDataReference{
+		ProcessAutomationJobId:        &job_id,
+		ProcessAutomationJobArguments: &adf_arg,
+	}
+	input := &AutomationActionsAction{
+		Name:                "Action created by TF",
+		Description:         &description,
+		ActionType:          "process_automation",
+		RunnerID:            &runner_id,
+		ActionDataReference: adf,
+	}
+
+	mux.HandleFunc("/automation_actions/actions", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		v := new(AutomationActionsActionPayload)
+		json.NewDecoder(r.Body).Decode(v)
+		if !reflect.DeepEqual(v.Action, input) {
+			t.Errorf("Request body = %+v, want %+v", v.Action, input)
+		}
+		w.Write([]byte(`{"action":{"action_data_reference":{"process_automation_job_id":"1519578e-a22a-4340-b58f-08194691e10b","process_automation_job_arguments":"-arg 123"},"action_type":"process_automation","creation_time":"2022-12-12T18:51:42.048162Z","description":"Description of Action created by TF","id":"01DF4OBNYKW84FS9CCYVYS1MOS","last_run":"2022-12-12T18:52:11.937747Z","last_run_by":{"id":"PINL781","type":"user_reference"},"modify_time":"2022-12-12T18:51:42.048162Z","name":"Action created by TF","privileges":{"permissions":["read"]},"runner":"01DF4O9T1MDPYOUT7SUX9EXZ4R","runner_type":"runbook","services":[{"id":"PQWQ0U6","type":"service_reference"}],"teams":[{"id":"PZ31N6S","type":"team_reference"}],"type":"action"}}`))
+	})
+
+	resp, _, err := client.AutomationActionsAction.Create(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	runner_type_runbook := "runbook"
+	modify_time := "2022-12-12T18:51:42.048162Z"
+	permissions_read := "read"
+	want := &AutomationActionsAction{
+		ID:           "01DF4OBNYKW84FS9CCYVYS1MOS",
+		Name:         "Action created by TF",
+		Description:  &description,
+		CreationTime: "2022-12-12T18:51:42.048162Z",
+		ActionType:   "process_automation",
+		Type:         "action",
+		RunnerID:     &runner_id,
+		RunnerType:   &runner_type_runbook,
+		Teams: []*TeamReference{
+			{
+				Type: "team_reference",
+				ID:   "PZ31N6S",
+			},
+		},
+		Services: []*ServiceReference{
+			{
+				Type: "service_reference",
+				ID:   "PQWQ0U6",
+			},
+		},
+		ActionDataReference: adf,
+		Privileges: &AutomationActionsPrivileges{
+			Permissions: []*string{&permissions_read},
+		},
+		ModifyTime: &modify_time,
+	}
+
+	if !reflect.DeepEqual(resp, want) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp, want)
+	}
+}
+
+func TestAutomationActionsActionDelete(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/automation_actions/actions/01DF4OBNYKW84FS9CCYVYS1MOS", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	if _, err := client.AutomationActionsAction.Delete("01DF4OBNYKW84FS9CCYVYS1MOS"); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pagerduty/automation_actions_action_test.go
+++ b/pagerduty/automation_actions_action_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func TestAutomationActionsScriptActionGet(t *testing.T) {
+func TestAutomationActionsActionTypeScriptGet(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -43,7 +43,7 @@ func TestAutomationActionsScriptActionGet(t *testing.T) {
 	}
 }
 
-func TestAutomationActionsProcessAutomationActionGet(t *testing.T) {
+func TestAutomationActionsActionTypeProcessAutomationGet(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -79,7 +79,7 @@ func TestAutomationActionsProcessAutomationActionGet(t *testing.T) {
 	}
 }
 
-func TestAutomationActionsActionCreate(t *testing.T) {
+func TestAutomationActionsActionTypeProcessAutomationCreate(t *testing.T) {
 	setup()
 	defer teardown()
 

--- a/pagerduty/pagerduty.go
+++ b/pagerduty/pagerduty.go
@@ -60,6 +60,7 @@ type Client struct {
 	BusinessServiceSubscribers *BusinessServiceSubscriberService
 	OnCall                     *OnCallService
 	AutomationActionsRunner    *AutomationActionsRunnerService
+	AutomationActionsAction    *AutomationActionsActionService
 }
 
 // Response is a wrapper around http.Response
@@ -123,6 +124,7 @@ func NewClient(config *Config) (*Client, error) {
 	c.BusinessServiceSubscribers = &BusinessServiceSubscriberService{c}
 	c.OnCall = &OnCallService{c}
 	c.AutomationActionsRunner = &AutomationActionsRunnerService{c}
+	c.AutomationActionsAction = &AutomationActionsActionService{c}
 
 	InitCache(c)
 	PopulateCache()


### PR DESCRIPTION
Added support for:

- Create an Action
  - POST https://api.pagerduty.com/automation_actions/actions
- Read an Action
  - GET https://api.pagerduty.com/automation_actions/actions/{id}
- Delete an Action
  - DELETE https://api.pagerduty.com/automation_actions/actions/{id}

New Test cases:
```
$ make test TESTARGS="-v -run TestAutomationActionsAction*"
==> Testing go-pagerduty
=== RUN   TestAutomationActionsActionTypeScriptGet
2022/12/14 10:44:21 ===== PagerDuty Cache Skipping Init =====
--- PASS: TestAutomationActionsActionTypeScriptGet (0.00s)
=== RUN   TestAutomationActionsActionTypeProcessAutomationGet
2022/12/14 10:44:21 ===== PagerDuty Cache Skipping Init =====
--- PASS: TestAutomationActionsActionTypeProcessAutomationGet (0.00s)
=== RUN   TestAutomationActionsActionTypeProcessAutomationCreate
2022/12/14 10:44:21 ===== PagerDuty Cache Skipping Init =====
--- PASS: TestAutomationActionsActionTypeProcessAutomationCreate (0.00s)
=== RUN   TestAutomationActionsActionDelete
2022/12/14 10:44:21 ===== PagerDuty Cache Skipping Init =====
--- PASS: TestAutomationActionsActionDelete (0.00s)
=== RUN   TestAutomationActionsActionTypeScriptCreate
2022/12/14 10:44:21 ===== PagerDuty Cache Skipping Init =====
--- PASS: TestAutomationActionsActionTypeScriptCreate (0.00s)
PASS
ok  	github.com/heimweh/go-pagerduty/pagerduty	0.245s
```