### PR TITLE
add support for `GET/POST/DELETE` action association to team

### DIFF
--- a/pagerduty/automation_actions_action.go
+++ b/pagerduty/automation_actions_action.go
@@ -34,6 +34,10 @@ type AutomationActionsActionPayload struct {
 	Action *AutomationActionsAction `json:"action,omitempty"`
 }
 
+type AutomationActionsActionTeamAssociationPayload struct {
+	Team *TeamReference `json:"team,omitempty"`
+}
+
 // Create creates a new action
 func (s *AutomationActionsActionService) Create(action *AutomationActionsAction) (*AutomationActionsAction, *Response, error) {
 	u := "/automation_actions/actions"
@@ -80,4 +84,55 @@ func (s *AutomationActionsActionService) Delete(id string) (*Response, error) {
 	}
 
 	return s.client.newRequestDoOptions("DELETE", u, nil, nil, nil, o)
+}
+
+// Associate an Automation Action with a team
+func (s *AutomationActionsActionService) AssociateToTeam(actionID, teamID string) (*AutomationActionsActionTeamAssociationPayload, *Response, error) {
+	u := fmt.Sprintf("/automation_actions/actions/%s/teams", actionID)
+	v := new(AutomationActionsActionTeamAssociationPayload)
+	o := RequestOptions{
+		Type:  "header",
+		Label: "X-EARLY-ACCESS",
+		Value: "automation-actions-early-access",
+	}
+	p := &AutomationActionsActionTeamAssociationPayload{
+		Team: &TeamReference{ID: teamID, Type: "team_reference"},
+	}
+
+	resp, err := s.client.newRequestDoOptions("POST", u, nil, p, &v, o)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v, resp, nil
+}
+
+// Dissociate an Automation Action with a team
+func (s *AutomationActionsActionService) DissociateToTeam(actionID, teamID string) (*Response, error) {
+	u := fmt.Sprintf("/automation_actions/actions/%s/teams/%s", actionID, teamID)
+	o := RequestOptions{
+		Type:  "header",
+		Label: "X-EARLY-ACCESS",
+		Value: "automation-actions-early-access",
+	}
+
+	return s.client.newRequestDoOptions("DELETE", u, nil, nil, nil, o)
+}
+
+// Gets the details of an Automation Action / team relation
+func (s *AutomationActionsActionService) GetAssociationToTeam(actionID, teamID string) (*AutomationActionsActionTeamAssociationPayload, *Response, error) {
+	u := fmt.Sprintf("/automation_actions/actions/%s/teams/%s", actionID, teamID)
+	v := new(AutomationActionsActionTeamAssociationPayload)
+	o := RequestOptions{
+		Type:  "header",
+		Label: "X-EARLY-ACCESS",
+		Value: "automation-actions-early-access",
+	}
+
+	resp, err := s.client.newRequestDoOptions("GET", u, nil, nil, &v, o)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v, resp, nil
 }

--- a/pagerduty/automation_actions_action_test.go
+++ b/pagerduty/automation_actions_action_test.go
@@ -2,6 +2,7 @@ package pagerduty
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"reflect"
 	"testing"
@@ -236,6 +237,78 @@ func TestAutomationActionsActionTypeScriptCreate(t *testing.T) {
 			Permissions: []*string{&permissions_read},
 		},
 		ModifyTime: &modify_time,
+	}
+
+	if !reflect.DeepEqual(resp, want) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp, want)
+	}
+}
+
+func TestAutomationActionsActionTeamAssociationCreate(t *testing.T) {
+	setup()
+	defer teardown()
+	actionID := "01DA2MLYN0J5EFC1LKWXUKDDKT"
+	teamID := "1"
+
+	mux.HandleFunc(fmt.Sprintf("/automation_actions/actions/%s/teams", actionID), func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		w.Write([]byte(`{"team":{"id":"1","type":"team_reference"}}`))
+	})
+
+	resp, _, err := client.AutomationActionsAction.AssociateToTeam(actionID, teamID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &AutomationActionsActionTeamAssociationPayload{
+		&TeamReference{
+			ID:   teamID,
+			Type: "team_reference",
+		},
+	}
+
+	if !reflect.DeepEqual(resp, want) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp, want)
+	}
+}
+
+func TestAutomationActionsActionTeamAssociationDelete(t *testing.T) {
+	setup()
+	defer teardown()
+	actionID := "01DA2MLYN0J5EFC1LKWXUKDDKT"
+	teamID := "1"
+
+	mux.HandleFunc(fmt.Sprintf("/automation_actions/actions/%s/teams/%s", actionID, teamID), func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	if _, err := client.AutomationActionsAction.DissociateToTeam(actionID, teamID); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAutomationActionsActionTeamAssociationGet(t *testing.T) {
+	setup()
+	defer teardown()
+	actionID := "01DA2MLYN0J5EFC1LKWXUKDDKT"
+	teamID := "1"
+
+	mux.HandleFunc(fmt.Sprintf("/automation_actions/actions/%s/teams/%s", actionID, teamID), func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		w.Write([]byte(`{"team":{"id":"1","type":"team_reference"}}`))
+	})
+
+	resp, _, err := client.AutomationActionsAction.GetAssociationToTeam(actionID, teamID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &AutomationActionsActionTeamAssociationPayload{
+		&TeamReference{
+			ID:   teamID,
+			Type: "team_reference",
+		},
 	}
 
 	if !reflect.DeepEqual(resp, want) {


### PR DESCRIPTION
Add support for Automation Actions' Action association with a Team...

* [GET](https://developer.pagerduty.com/api-reference/104eeb114d28a-get-the-details-of-an-automation-action-team-relation) - `https://api.pagerduty.com/automation_actions/actions/{id}/teams/{team_id}`
* [POST](https://developer.pagerduty.com/api-reference/8f722dd91a4ba-associate-an-automation-action-with-a-team) - `https://api.pagerduty.com/automation_actions/actions/{id}/teams`
* [DELETE](https://developer.pagerduty.com/api-reference/ee349feadcc5f-disassociate-an-automation-action-from-a-team) - `https://api.pagerduty.com/automation_actions/actions/{id}/teams/{team_id}`

New tests cases introduced...
![Screenshot 2022-12-14 at 12 10 51](https://user-images.githubusercontent.com/24704624/207633909-1fc2e621-9c81-48e2-87f1-8a1660437df6.png)
