### PR TITLE
Add supports for Automation Actions Action Update

### DIFF
--- a/pagerduty/automation_actions_action.go
+++ b/pagerduty/automation_actions_action.go
@@ -38,9 +38,11 @@ type AutomationActionsActionTeamAssociationPayload struct {
 	Team *TeamReference `json:"team,omitempty"`
 }
 
+var automationActionsActionBaseUrl = "/automation_actions/actions"
+
 // Create creates a new action
 func (s *AutomationActionsActionService) Create(action *AutomationActionsAction) (*AutomationActionsAction, *Response, error) {
-	u := "/automation_actions/actions"
+	u := automationActionsActionBaseUrl
 	v := new(AutomationActionsActionPayload)
 	o := RequestOptions{
 		Type:  "header",
@@ -58,7 +60,7 @@ func (s *AutomationActionsActionService) Create(action *AutomationActionsAction)
 
 // Get retrieves information about an action.
 func (s *AutomationActionsActionService) Get(id string) (*AutomationActionsAction, *Response, error) {
-	u := fmt.Sprintf("/automation_actions/actions/%s", id)
+	u := fmt.Sprintf("%s/%s", automationActionsActionBaseUrl, id)
 	v := new(AutomationActionsActionPayload)
 	o := RequestOptions{
 		Type:  "header",
@@ -74,9 +76,23 @@ func (s *AutomationActionsActionService) Get(id string) (*AutomationActionsActio
 	return v.Action, resp, nil
 }
 
+// Update an existing action
+func (s *AutomationActionsActionService) Update(ID string, action *AutomationActionsAction) (*AutomationActionsAction, *Response, error) {
+	u := fmt.Sprintf("%s/%s", automationActionsActionBaseUrl, ID)
+	v := new(AutomationActionsActionPayload)
+	p := &AutomationActionsActionPayload{Action: action}
+
+	resp, err := s.client.newRequestDo("PUT", u, nil, p, v)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v.Action, resp, nil
+}
+
 // Delete deletes an existing action.
 func (s *AutomationActionsActionService) Delete(id string) (*Response, error) {
-	u := fmt.Sprintf("/automation_actions/actions/%s", id)
+	u := fmt.Sprintf("%s/%s", automationActionsActionBaseUrl, id)
 	o := RequestOptions{
 		Type:  "header",
 		Label: "X-EARLY-ACCESS",
@@ -88,7 +104,7 @@ func (s *AutomationActionsActionService) Delete(id string) (*Response, error) {
 
 // Associate an Automation Action with a team
 func (s *AutomationActionsActionService) AssociateToTeam(actionID, teamID string) (*AutomationActionsActionTeamAssociationPayload, *Response, error) {
-	u := fmt.Sprintf("/automation_actions/actions/%s/teams", actionID)
+	u := fmt.Sprintf("%s/%s/teams", automationActionsActionBaseUrl, actionID)
 	v := new(AutomationActionsActionTeamAssociationPayload)
 	o := RequestOptions{
 		Type:  "header",
@@ -109,7 +125,7 @@ func (s *AutomationActionsActionService) AssociateToTeam(actionID, teamID string
 
 // Dissociate an Automation Action with a team
 func (s *AutomationActionsActionService) DissociateToTeam(actionID, teamID string) (*Response, error) {
-	u := fmt.Sprintf("/automation_actions/actions/%s/teams/%s", actionID, teamID)
+	u := fmt.Sprintf("%s/%s/teams/%s", automationActionsActionBaseUrl, actionID, teamID)
 	o := RequestOptions{
 		Type:  "header",
 		Label: "X-EARLY-ACCESS",
@@ -121,7 +137,7 @@ func (s *AutomationActionsActionService) DissociateToTeam(actionID, teamID strin
 
 // Gets the details of an Automation Action / team relation
 func (s *AutomationActionsActionService) GetAssociationToTeam(actionID, teamID string) (*AutomationActionsActionTeamAssociationPayload, *Response, error) {
-	u := fmt.Sprintf("/automation_actions/actions/%s/teams/%s", actionID, teamID)
+	u := fmt.Sprintf("%s/%s/teams/%s", automationActionsActionBaseUrl, actionID, teamID)
 	v := new(AutomationActionsActionTeamAssociationPayload)
 	o := RequestOptions{
 		Type:  "header",

--- a/pagerduty/automation_actions_action_test.go
+++ b/pagerduty/automation_actions_action_test.go
@@ -157,6 +157,82 @@ func TestAutomationActionsActionTypeProcessAutomationCreate(t *testing.T) {
 	}
 }
 
+func TestAutomationActionsActionUpdate(t *testing.T) {
+	setup()
+	defer teardown()
+
+	description := "Description of Action created by TF"
+	runner_id := "01DF4O9T1MDPYOUT7SUX9EXZ4R"
+	adf_arg := "-arg 123"
+	job_id := "1519578e-a22a-4340-b58f-08194691e10b"
+	adf := AutomationActionsActionDataReference{
+		ProcessAutomationJobId:        &job_id,
+		ProcessAutomationJobArguments: &adf_arg,
+	}
+	input := &AutomationActionsAction{
+		Name:                "Action created by TF",
+		Description:         &description,
+		ActionType:          "process_automation",
+		RunnerID:            &runner_id,
+		ActionDataReference: adf,
+	}
+
+	var id = "01DF4OBNYKW84FS9CCYVYS1MOS"
+	var url = fmt.Sprintf("%s/%s", automationActionsActionBaseUrl, id)
+
+	mux.HandleFunc(url, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		v := new(AutomationActionsActionPayload)
+		json.NewDecoder(r.Body).Decode(v)
+		if !reflect.DeepEqual(v.Action, input) {
+			t.Errorf("Request body = %+v, want %+v", v.Action, input)
+		}
+		w.Write([]byte(`{"action":{"action_data_reference":{"process_automation_job_id":"1519578e-a22a-4340-b58f-08194691e10b","process_automation_job_arguments":"-arg 123"},"action_type":"process_automation","creation_time":"2022-12-12T18:51:42.048162Z","description":"Description of Action created by TF","id":"01DF4OBNYKW84FS9CCYVYS1MOS","last_run":"2022-12-12T18:52:11.937747Z","last_run_by":{"id":"PINL781","type":"user_reference"},"modify_time":"2022-12-12T18:51:42.048162Z","name":"Action created by TF","privileges":{"permissions":["read"]},"runner":"01DF4O9T1MDPYOUT7SUX9EXZ4R","runner_type":"runbook","services":[{"id":"PQWQ0U6","type":"service_reference"}],"teams":[{"id":"PZ31N6S","type":"team_reference"}],"type":"action"}}`))
+	})
+
+	resp, _, err := client.AutomationActionsAction.Update(id, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	runner_type_runbook := "runbook"
+	modify_time := "2022-12-12T18:51:42.048162Z"
+	permissions_read := "read"
+	resource_type := "action"
+	creation_time := "2022-12-12T18:51:42.048162Z"
+	want := &AutomationActionsAction{
+		ID:           id,
+		Name:         "Action created by TF",
+		Description:  &description,
+		CreationTime: &creation_time,
+		ActionType:   "process_automation",
+		Type:         &resource_type,
+		RunnerID:     &runner_id,
+		RunnerType:   &runner_type_runbook,
+		Teams: []*TeamReference{
+			{
+				Type: "team_reference",
+				ID:   "PZ31N6S",
+			},
+		},
+		Services: []*ServiceReference{
+			{
+				Type: "service_reference",
+				ID:   "PQWQ0U6",
+			},
+		},
+		ActionDataReference: adf,
+		Privileges: &AutomationActionsPrivileges{
+			Permissions: []*string{&permissions_read},
+		},
+		ModifyTime: &modify_time,
+	}
+
+	if !reflect.DeepEqual(resp, want) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp, want)
+	}
+}
+
 func TestAutomationActionsActionDelete(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
Added support for:

- Update an Action
  - PUT https://api.pagerduty.com/automation_actions/actions/{id}

New Tests:
```
make test TESTARGS="-v -run TestAutomationActionsActionUpdate"
==> Testing go-pagerduty
=== RUN   TestAutomationActionsActionUpdate
2022/12/19 16:55:01 ===== PagerDuty Cache Skipping Init =====
--- PASS: TestAutomationActionsActionUpdate (0.00s)
PASS
ok  	github.com/heimweh/go-pagerduty/pagerduty	0.239s
```