### PR TITLE
add team support for incident workflows

### DIFF
--- a/pagerduty/incident_workflow.go
+++ b/pagerduty/incident_workflow.go
@@ -17,6 +17,7 @@ type IncidentWorkflow struct {
 	Description *string                 `json:"description,omitempty"`
 	Self        string                  `json:"self,omitempty"`
 	Steps       []*IncidentWorkflowStep `json:"steps,omitempty"`
+	Team        *TeamReference          `json:"team,omitempty"`
 }
 
 // IncidentWorkflowStep represents a step in an incident workflow.

--- a/pagerduty/incident_workflow_test.go
+++ b/pagerduty/incident_workflow_test.go
@@ -200,6 +200,10 @@ func TestIncidentWorkflowGet(t *testing.T) {
     "html_url": "https://subdomain.pagerduty.com/flex-workflows/workflows/TO38234/edit",
     "created_at": "2022-06-07T00:01:55Z",
     "last_started_at": "2022-06-07T00:01:55Z",
+    "team": {
+        "type": "team_reference",
+        "id": "T1"
+    },
     "steps": [
       {
         "id": "32OIHWEJ",
@@ -272,6 +276,10 @@ func TestIncidentWorkflowGet(t *testing.T) {
 		Name:        "Example Workflow",
 		Description: &workflowDesc,
 		Self:        "https://api.pagerduty.com/incident_workflows/TO38234",
+		Team: &TeamReference{
+			Type: "team_reference",
+			ID:   "T1",
+		},
 		Steps: []*IncidentWorkflowStep{
 			{
 				ID:          "32OIHWEJ",


### PR DESCRIPTION
Incident workflows support a `team` property which enables scoping edit permissions. See https://developer.pagerduty.com/api-reference/2d183500bb4fb-create-an-incident-workflow

This change adds support for that property in the go client

PR for [terraform-provider-pagerduty ](https://github.com/PagerDuty/terraform-provider-pagerduty) will follow based on https://github.com/PagerDuty/terraform-provider-pagerduty/compare/master...jedelson-pagerduty:terraform-provider-pagerduty:issue/incident-workflow-teams