### PR TITLE
add support for GET/POST/DELETE runner association to team

### DIFF
--- a/pagerduty/automation_actions_runner.go
+++ b/pagerduty/automation_actions_runner.go
@@ -31,6 +31,10 @@ type AutomationActionsRunnerPayload struct {
 
 var automationActionsRunnerBaseUrl = "/automation_actions/runners"
 
+type AutomationActionsRunnerTeamAssociationPayload struct {
+	Team *TeamReference `json:"team,omitempty"`
+}
+
 // Create creates a new runner
 func (s *AutomationActionsRunnerService) Create(runner *AutomationActionsRunner) (*AutomationActionsRunner, *Response, error) {
 	u := automationActionsRunnerBaseUrl
@@ -76,4 +80,40 @@ func (s *AutomationActionsRunnerService) Delete(id string) (*Response, error) {
 	u := fmt.Sprintf("%s/%s", automationActionsRunnerBaseUrl, id)
 
 	return s.client.newRequestDoOptions("DELETE", u, nil, nil, nil)
+}
+
+// Associate a Runner with a team
+func (s *AutomationActionsRunnerService) AssociateToTeam(runnerID, teamID string) (*AutomationActionsRunnerTeamAssociationPayload, *Response, error) {
+	u := fmt.Sprintf("/automation_actions/runners/%s/teams", runnerID)
+	v := new(AutomationActionsRunnerTeamAssociationPayload)
+	p := &AutomationActionsRunnerTeamAssociationPayload{
+		Team: &TeamReference{ID: teamID, Type: "team_reference"},
+	}
+
+	resp, err := s.client.newRequestDoOptions("POST", u, nil, p, &v)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v, resp, nil
+}
+
+// Dissociate an Runner with a team
+func (s *AutomationActionsRunnerService) DissociateToTeam(runnerID, teamID string) (*Response, error) {
+	u := fmt.Sprintf("/automation_actions/runners/%s/teams/%s", runnerID, teamID)
+
+	return s.client.newRequestDoOptions("DELETE", u, nil, nil, nil)
+}
+
+// Gets the details of a Runner / team relation
+func (s *AutomationActionsRunnerService) GetAssociationToTeam(runnerID, teamID string) (*AutomationActionsRunnerTeamAssociationPayload, *Response, error) {
+	u := fmt.Sprintf("/automation_actions/runners/%s/teams/%s", runnerID, teamID)
+	v := new(AutomationActionsRunnerTeamAssociationPayload)
+
+	resp, err := s.client.newRequestDoOptions("GET", u, nil, nil, &v)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v, resp, nil
 }

--- a/pagerduty/automation_actions_runner.go
+++ b/pagerduty/automation_actions_runner.go
@@ -29,11 +29,11 @@ type AutomationActionsRunnerPayload struct {
 	Runner *AutomationActionsRunner `json:"runner,omitempty"`
 }
 
-var automationActionsRunnerBaseUrl = "/automation_actions/runners"
-
 type AutomationActionsRunnerTeamAssociationPayload struct {
 	Team *TeamReference `json:"team,omitempty"`
 }
+
+var automationActionsRunnerBaseUrl = "/automation_actions/runners"
 
 // Create creates a new runner
 func (s *AutomationActionsRunnerService) Create(runner *AutomationActionsRunner) (*AutomationActionsRunner, *Response, error) {
@@ -84,7 +84,7 @@ func (s *AutomationActionsRunnerService) Delete(id string) (*Response, error) {
 
 // Associate a Runner with a team
 func (s *AutomationActionsRunnerService) AssociateToTeam(runnerID, teamID string) (*AutomationActionsRunnerTeamAssociationPayload, *Response, error) {
-	u := fmt.Sprintf("/automation_actions/runners/%s/teams", runnerID)
+	u := fmt.Sprintf("%s/%s/teams", automationActionsRunnerBaseUrl, runnerID)
 	v := new(AutomationActionsRunnerTeamAssociationPayload)
 	p := &AutomationActionsRunnerTeamAssociationPayload{
 		Team: &TeamReference{ID: teamID, Type: "team_reference"},
@@ -100,14 +100,14 @@ func (s *AutomationActionsRunnerService) AssociateToTeam(runnerID, teamID string
 
 // Dissociate an Runner with a team
 func (s *AutomationActionsRunnerService) DissociateFromTeam(runnerID, teamID string) (*Response, error) {
-	u := fmt.Sprintf("/automation_actions/runners/%s/teams/%s", runnerID, teamID)
+	u := fmt.Sprintf("%s/%s/teams/%s", automationActionsRunnerBaseUrl, runnerID, teamID)
 
 	return s.client.newRequestDoOptions("DELETE", u, nil, nil, nil)
 }
 
 // Gets the details of a Runner / team relation
 func (s *AutomationActionsRunnerService) GetAssociationToTeam(runnerID, teamID string) (*AutomationActionsRunnerTeamAssociationPayload, *Response, error) {
-	u := fmt.Sprintf("/automation_actions/runners/%s/teams/%s", runnerID, teamID)
+	u := fmt.Sprintf("%s/%s/teams/%s", automationActionsRunnerBaseUrl, runnerID, teamID)
 	v := new(AutomationActionsRunnerTeamAssociationPayload)
 
 	resp, err := s.client.newRequestDoOptions("GET", u, nil, nil, &v)

--- a/pagerduty/automation_actions_runner.go
+++ b/pagerduty/automation_actions_runner.go
@@ -99,7 +99,7 @@ func (s *AutomationActionsRunnerService) AssociateToTeam(runnerID, teamID string
 }
 
 // Dissociate an Runner with a team
-func (s *AutomationActionsRunnerService) DissociateToTeam(runnerID, teamID string) (*Response, error) {
+func (s *AutomationActionsRunnerService) DissociateFromTeam(runnerID, teamID string) (*Response, error) {
 	u := fmt.Sprintf("/automation_actions/runners/%s/teams/%s", runnerID, teamID)
 
 	return s.client.newRequestDoOptions("DELETE", u, nil, nil, nil)

--- a/pagerduty/automation_actions_runner_test.go
+++ b/pagerduty/automation_actions_runner_test.go
@@ -184,3 +184,75 @@ func TestAutomationActionsRunnerDelete(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestAutomationActionsRunnerTeamAssociationCreate(t *testing.T) {
+	setup()
+	defer teardown()
+	runnerID := "01DA2MLYN0J5EFC1LKWXUKDDKT"
+	teamID := "PQ9K7I8"
+
+	mux.HandleFunc(fmt.Sprintf("/automation_actions/runners/%s/teams", runnerID), func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		w.Write([]byte(`{"team":{"id":"PQ9K7I8","type":"team_reference"}}`))
+	})
+
+	resp, _, err := client.AutomationActionsRunner.AssociateToTeam(runnerID, teamID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &AutomationActionsRunnerTeamAssociationPayload{
+		&TeamReference{
+			ID:   teamID,
+			Type: "team_reference",
+		},
+	}
+
+	if !reflect.DeepEqual(resp, want) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp, want)
+	}
+}
+
+func TestAutomationActionsRunnerTeamAssociationDelete(t *testing.T) {
+	setup()
+	defer teardown()
+	runnerID := "01DA2MLYN0J5EFC1LKWXUKDDKT"
+	teamID := "PQ9K7I8"
+
+	mux.HandleFunc(fmt.Sprintf("/automation_actions/runners/%s/teams/%s", runnerID, teamID), func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	if _, err := client.AutomationActionsRunner.DissociateToTeam(runnerID, teamID); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAutomationActionsRunnerTeamAssociationGet(t *testing.T) {
+	setup()
+	defer teardown()
+	runnerID := "01DA2MLYN0J5EFC1LKWXUKDDKT"
+	teamID := "PQ9K7I8"
+
+	mux.HandleFunc(fmt.Sprintf("/automation_actions/runners/%s/teams/%s", runnerID, teamID), func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		w.Write([]byte(`{"team":{"id":"PQ9K7I8","type":"team_reference"}}`))
+	})
+
+	resp, _, err := client.AutomationActionsRunner.GetAssociationToTeam(runnerID, teamID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &AutomationActionsRunnerTeamAssociationPayload{
+		&TeamReference{
+			ID:   teamID,
+			Type: "team_reference",
+		},
+	}
+
+	if !reflect.DeepEqual(resp, want) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp, want)
+	}
+}

--- a/pagerduty/automation_actions_runner_test.go
+++ b/pagerduty/automation_actions_runner_test.go
@@ -224,7 +224,7 @@ func TestAutomationActionsRunnerTeamAssociationDelete(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	if _, err := client.AutomationActionsRunner.DissociateToTeam(runnerID, teamID); err != nil {
+	if _, err := client.AutomationActionsRunner.DissociateFromTeam(runnerID, teamID); err != nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
Add support for Automation Actions' Runner association with a Team...

- GET - https://api.pagerduty.com/automation_actions/runners/{id}/teams/{team_id} 
- POST - https://api.pagerduty.com/automation_actions/runners/{id}/teams 
- DELETE - https://api.pagerduty.com/automation_actions/runners/{id}/teams/{team_id}

New tests cases introduced:
```
$ make test TESTARGS="-v -run TestAutomationActionsRunnerTeamAssociation"
==> Testing go-pagerduty
=== RUN   TestAutomationActionsRunnerTeamAssociationCreate
2023/01/05 13:36:11 ===== PagerDuty Cache Skipping Init =====
--- PASS: TestAutomationActionsRunnerTeamAssociationCreate (0.00s)
=== RUN   TestAutomationActionsRunnerTeamAssociationDelete
2023/01/05 13:36:11 ===== PagerDuty Cache Skipping Init =====
--- PASS: TestAutomationActionsRunnerTeamAssociationDelete (0.00s)
=== RUN   TestAutomationActionsRunnerTeamAssociationGet
2023/01/05 13:36:11 ===== PagerDuty Cache Skipping Init =====
--- PASS: TestAutomationActionsRunnerTeamAssociationGet (0.00s)
PASS
ok  	github.com/heimweh/go-pagerduty/pagerduty	0.291s
```