### PR TITLE
add support for `GET/POST/DELETE` action association to a service

### DIFF
--- a/pagerduty/automation_actions_action.go
+++ b/pagerduty/automation_actions_action.go
@@ -144,7 +144,7 @@ func (s *AutomationActionsActionService) AssociateToService(actionID, serviceID 
 }
 
 // Dissociate an Automation Action with a service
-func (s *AutomationActionsActionService) DissociateToService(actionID, serviceID string) (*Response, error) {
+func (s *AutomationActionsActionService) DissociateFromService(actionID, serviceID string) (*Response, error) {
 	u := fmt.Sprintf("%s/%s/services/%s", automationActionsActionBaseUrl, actionID, serviceID)
 
 	return s.client.newRequestDoOptions("DELETE", u, nil, nil, nil)

--- a/pagerduty/automation_actions_action.go
+++ b/pagerduty/automation_actions_action.go
@@ -38,6 +38,10 @@ type AutomationActionsActionTeamAssociationPayload struct {
 	Team *TeamReference `json:"team,omitempty"`
 }
 
+type AutomationActionsActionServiceAssociationPayload struct {
+	Service *ServiceReference `json:"service,omitempty"`
+}
+
 var automationActionsActionBaseUrl = "/automation_actions/actions"
 
 // Create creates a new action
@@ -114,6 +118,42 @@ func (s *AutomationActionsActionService) DissociateToTeam(actionID, teamID strin
 func (s *AutomationActionsActionService) GetAssociationToTeam(actionID, teamID string) (*AutomationActionsActionTeamAssociationPayload, *Response, error) {
 	u := fmt.Sprintf("%s/%s/teams/%s", automationActionsActionBaseUrl, actionID, teamID)
 	v := new(AutomationActionsActionTeamAssociationPayload)
+
+	resp, err := s.client.newRequestDoOptions("GET", u, nil, nil, &v)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v, resp, nil
+}
+
+// Associate an Automation Action with a service
+func (s *AutomationActionsActionService) AssociateToService(actionID, serviceID string) (*AutomationActionsActionServiceAssociationPayload, *Response, error) {
+	u := fmt.Sprintf("%s/%s/services", automationActionsActionBaseUrl, actionID)
+	v := new(AutomationActionsActionServiceAssociationPayload)
+	p := &AutomationActionsActionServiceAssociationPayload{
+		Service: &ServiceReference{ID: serviceID, Type: "service_reference"},
+	}
+
+	resp, err := s.client.newRequestDoOptions("POST", u, nil, p, &v)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v, resp, nil
+}
+
+// Dissociate an Automation Action with a service
+func (s *AutomationActionsActionService) DissociateToService(actionID, serviceID string) (*Response, error) {
+	u := fmt.Sprintf("%s/%s/services/%s", automationActionsActionBaseUrl, actionID, serviceID)
+
+	return s.client.newRequestDoOptions("DELETE", u, nil, nil, nil)
+}
+
+// Gets the details of an Automation Action / service relation
+func (s *AutomationActionsActionService) GetAssociationToService(actionID, serviceID string) (*AutomationActionsActionServiceAssociationPayload, *Response, error) {
+	u := fmt.Sprintf("%s/%s/services/%s", automationActionsActionBaseUrl, actionID, serviceID)
+	v := new(AutomationActionsActionServiceAssociationPayload)
 
 	resp, err := s.client.newRequestDoOptions("GET", u, nil, nil, &v)
 	if err != nil {

--- a/pagerduty/automation_actions_action_test.go
+++ b/pagerduty/automation_actions_action_test.go
@@ -391,3 +391,75 @@ func TestAutomationActionsActionTeamAssociationGet(t *testing.T) {
 		t.Errorf("returned \n\n%#v want \n\n%#v", resp, want)
 	}
 }
+
+func TestAutomationActionsActionServiceAssociationCreate(t *testing.T) {
+	setup()
+	defer teardown()
+	actionID := "01DA2MLYN0J5EFC1LKWXUKDDKT"
+	serviceID := "1"
+
+	mux.HandleFunc(fmt.Sprintf("/automation_actions/actions/%s/services", actionID), func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		w.Write([]byte(`{"service":{"id":"1","type":"service_reference"}}`))
+	})
+
+	resp, _, err := client.AutomationActionsAction.AssociateToService(actionID, serviceID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &AutomationActionsActionServiceAssociationPayload{
+		&ServiceReference{
+			ID:   serviceID,
+			Type: "service_reference",
+		},
+	}
+
+	if !reflect.DeepEqual(resp, want) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp, want)
+	}
+}
+
+func TestAutomationActionsActionServiceAssociationDelete(t *testing.T) {
+	setup()
+	defer teardown()
+	actionID := "01DA2MLYN0J5EFC1LKWXUKDDKT"
+	serviceID := "1"
+
+	mux.HandleFunc(fmt.Sprintf("/automation_actions/actions/%s/services/%s", actionID, serviceID), func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	if _, err := client.AutomationActionsAction.DissociateToService(actionID, serviceID); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAutomationActionsActionServiceAssociationGet(t *testing.T) {
+	setup()
+	defer teardown()
+	actionID := "01DA2MLYN0J5EFC1LKWXUKDDKT"
+	serviceID := "1"
+
+	mux.HandleFunc(fmt.Sprintf("/automation_actions/actions/%s/services/%s", actionID, serviceID), func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		w.Write([]byte(`{"service":{"id":"1","type":"service_reference"}}`))
+	})
+
+	resp, _, err := client.AutomationActionsAction.GetAssociationToService(actionID, serviceID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &AutomationActionsActionServiceAssociationPayload{
+		&ServiceReference{
+			ID:   serviceID,
+			Type: "service_reference",
+		},
+	}
+
+	if !reflect.DeepEqual(resp, want) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp, want)
+	}
+}

--- a/pagerduty/automation_actions_action_test.go
+++ b/pagerduty/automation_actions_action_test.go
@@ -431,7 +431,7 @@ func TestAutomationActionsActionServiceAssociationDelete(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	if _, err := client.AutomationActionsAction.DissociateToService(actionID, serviceID); err != nil {
+	if _, err := client.AutomationActionsAction.DissociateFromService(actionID, serviceID); err != nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
Add support for Automation Actions' Action association with a Service...

* [GET](https://developer.pagerduty.com/api-reference/c819b2c910b0e-get-the-details-of-an-automation-action-service-relation) - `https://api.pagerduty.com/automation_actions/actions/{id}/services/{team_id}`
* [POST](https://developer.pagerduty.com/api-reference/5d2f051f3fb43-associate-an-automation-action-with-a-service) - `https://api.pagerduty.com/automation_actions/services/{id}/teams`
* [DELETE](https://developer.pagerduty.com/api-reference/0545bf66a29b2-disassociate-an-automation-action-from-a-service) - `https://api.pagerduty.com/automation_actions/actions/{id}/services/{team_id}`

New tests cases introduced...
```sh
make test TESTARGS="-v -run TestAutomationActionsActionServiceAssociation"
==> Testing go-pagerduty
=== RUN   TestAutomationActionsActionServiceAssociationCreate
2023/01/05 16:36:22 ===== PagerDuty Cache Skipping Init =====
--- PASS: TestAutomationActionsActionServiceAssociationCreate (0.00s)
=== RUN   TestAutomationActionsActionServiceAssociationDelete
2023/01/05 16:36:22 ===== PagerDuty Cache Skipping Init =====
--- PASS: TestAutomationActionsActionServiceAssociationDelete (0.00s)
=== RUN   TestAutomationActionsActionServiceAssociationGet
2023/01/05 16:36:22 ===== PagerDuty Cache Skipping Init =====
--- PASS: TestAutomationActionsActionServiceAssociationGet (0.00s)
PASS
ok      github.com/heimweh/go-pagerduty/pagerduty       0.426s
```