### PR TITLE
team.go: add support for private teams.

### DIFF
--- a/pagerduty/team.go
+++ b/pagerduty/team.go
@@ -16,6 +16,7 @@ type Team struct {
 	Summary     string         `json:"summary,omitempty"`
 	Type        string         `json:"type,omitempty"`
 	Parent      *TeamReference `json:"parent,omitempty"`
+	DefaultRole string         `json:"default_role,omitempty"`
 }
 
 // Member represents a team member.


### PR DESCRIPTION
## What

Adds support for creating private teams in pagerduty.

## Why

In accounts with advance permissions enabled the key `default_role` must be set in the request payload.
This package needs to be patched so that we can update the pagerduty [provider](https://github.com/PagerDuty/terraform-provider-pagerduty/pull/612) which uses this package .
The payload key is not documented on the website, it was found using developer tools on the browser.
Setting `default_role: none` results in a private team.

## Test cURL

```console
curl --request POST \
  --url https://api.pagerduty.com/teams \
  --header 'Accept: application/vnd.pagerduty+json;version=2' \
  --header 'Authorization: Token token=xxxxxxxxxxxx' \
  --header 'Content-Type: application/json' \
  --data '{
  "team": {
    "type": "team",
    "name": "arjun-test",
    "description": "The engineering team",
    "default_role": "none"
  }
}'
```
Ref:
- https://developer.pagerduty.com/api-reference/2e80b2c79165e-create-a-team
- https://github.com/PagerDuty/terraform-provider-pagerduty/issues/611
