### PR TITLE
Test and restore paged resources support

### DIFF
--- a/pagerduty/pagerduty.go
+++ b/pagerduty/pagerduty.go
@@ -293,15 +293,15 @@ type offsetQueryOptionsGen interface {
 }
 
 type simpleOffsetQueryOptionsGen struct {
-	offset int `url:"offset,omitempty"`
+	Offset int `url:"offset,omitempty"`
 }
 
 func (o *simpleOffsetQueryOptionsGen) currentOffset() int {
-	return o.offset
+	return o.Offset
 }
 
 func (o *simpleOffsetQueryOptionsGen) changeOffset(i int) {
-	o.offset = i
+	o.Offset = i
 }
 
 func (o *simpleOffsetQueryOptionsGen) buildStruct() interface{} {


### PR DESCRIPTION
Paged resources such as teams with over 100 members are currently leading to an infinite loop.

Looks like this functionality has been lost in #104 .

I'm adding a test to ensure this is checked for in the future.