### PR TITLE
Event Orchestration Updates: Orchestration Warnings, Global Orchestrations, Orchestration Integrations

### DIFF
--- a/pagerduty/event_orchestration.go
+++ b/pagerduty/event_orchestration.go
@@ -20,16 +20,6 @@ type EventOrchestrationObject struct {
 	ID   *string `json:"id"`
 }
 
-type EventOrchestrationIntegrationParameters struct {
-	RoutingKey string `json:"routing_key,omitempty"`
-	Type       string `json:"type,omitempty"`
-}
-
-type EventOrchestrationIntegration struct {
-	ID         string                                   `json:"id,omitempty"`
-	Parameters *EventOrchestrationIntegrationParameters `json:"parameters,omitempty"`
-}
-
 type EventOrchestrationPayload struct {
 	Orchestration *EventOrchestration `json:"orchestration,omitempty"`
 }

--- a/pagerduty/event_orchestration_integration.go
+++ b/pagerduty/event_orchestration_integration.go
@@ -1,0 +1,143 @@
+package pagerduty
+
+import (
+	"context"
+	"fmt"
+)
+
+type EventOrchestrationIntegrationService service
+
+type EventOrchestrationIntegrationParameters struct {
+	RoutingKey string `json:"routing_key,omitempty"`
+	Type       string `json:"type,omitempty"`
+}
+
+type EventOrchestrationIntegration struct {
+	ID         string                                   `json:"id,omitempty"`
+	Label      string                                   `json:"label,omitempty"`
+	Parameters *EventOrchestrationIntegrationParameters `json:"parameters,omitempty"`
+}
+
+type EventOrchestrationIntegrationPayload struct {
+	Integration *EventOrchestrationIntegration `json:"integration,omitempty"`
+}
+
+type EventOrchestrationIntegrationMigrationPayload struct {
+	SourceType    string `json:"source_type,omitempty"`
+	SourceId      string `json:"source_id,omitempty"`
+	IntegrationId string `json:"integration_id,omitempty"`
+}
+
+type ListEventOrchestrationIntegrationsResponse struct {
+	Total        int                              `json:"total,omitempty"`
+	Integrations []*EventOrchestrationIntegration `json:"integrations,omitempty"`
+}
+
+func buildEventOrchestrationIntegrationUrl(orchestrationId string, lastUrlSegment string) string {
+	url := fmt.Sprintf("%s/%s/integrations", eventOrchestrationBaseUrl, orchestrationId)
+
+	if len(lastUrlSegment) > 0 {
+		url = fmt.Sprintf("%s/%s", url, lastUrlSegment)
+	}
+
+	return url
+}
+
+func (s *EventOrchestrationIntegrationService) List(orchestrationId string) (*ListEventOrchestrationIntegrationsResponse, *Response, error) {
+	return s.ListContext(context.Background(), orchestrationId)
+}
+
+func (s *EventOrchestrationIntegrationService) ListContext(ctx context.Context, orchestrationId string) (*ListEventOrchestrationIntegrationsResponse, *Response, error) {
+	u := buildEventOrchestrationIntegrationUrl(orchestrationId, "")
+	v := new(ListEventOrchestrationIntegrationsResponse)
+
+	resp, err := s.client.newRequestDoContext(ctx, "GET", u, nil, nil, v)
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v, resp, nil
+}
+
+func (s *EventOrchestrationIntegrationService) Create(orchestrationId string, integration *EventOrchestrationIntegration) (*EventOrchestrationIntegration, *Response, error) {
+	return s.CreateContext(context.Background(), orchestrationId, integration)
+}
+
+func (s *EventOrchestrationIntegrationService) CreateContext(ctx context.Context, orchestrationId string, integration *EventOrchestrationIntegration) (*EventOrchestrationIntegration, *Response, error) {
+	u := buildEventOrchestrationIntegrationUrl(orchestrationId, "")
+	v := new(EventOrchestrationIntegrationPayload)
+	p := &EventOrchestrationIntegrationPayload{Integration: integration}
+
+	resp, err := s.client.newRequestDoContext(ctx, "POST", u, nil, p, v)
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v.Integration, resp, nil
+}
+
+func (s *EventOrchestrationIntegrationService) Get(orchestrationId string, id string) (*EventOrchestrationIntegration, *Response, error) {
+	return s.GetContext(context.Background(), orchestrationId, id)
+}
+
+func (s *EventOrchestrationIntegrationService) GetContext(ctx context.Context, orchestrationId string, id string) (*EventOrchestrationIntegration, *Response, error) {
+	u := buildEventOrchestrationIntegrationUrl(orchestrationId, id)
+	v := new(EventOrchestrationIntegrationPayload)
+
+	resp, err := s.client.newRequestDoContext(ctx, "GET", u, nil, nil, v)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v.Integration, resp, nil
+}
+
+func (s *EventOrchestrationIntegrationService) Update(orchestrationId string, id string, integration *EventOrchestrationIntegration) (*EventOrchestrationIntegration, *Response, error) {
+	return s.UpdateContext(context.Background(), orchestrationId, id, integration)
+}
+
+func (s *EventOrchestrationIntegrationService) UpdateContext(ctx context.Context, orchestrationId string, id string, integration *EventOrchestrationIntegration) (*EventOrchestrationIntegration, *Response, error) {
+	u := buildEventOrchestrationIntegrationUrl(orchestrationId, id)
+	v := new(EventOrchestrationIntegrationPayload)
+	p := &EventOrchestrationIntegrationPayload{Integration: integration}
+
+	resp, err := s.client.newRequestDoContext(ctx, "PUT", u, nil, p, v)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v.Integration, resp, nil
+}
+
+func (s *EventOrchestrationIntegrationService) Delete(orchestrationId string, id string) (*Response, error) {
+	return s.DeleteContext(context.Background(), orchestrationId, id)
+}
+
+func (s *EventOrchestrationIntegrationService) DeleteContext(ctx context.Context, orchestrationId string, id string) (*Response, error) {
+	u := buildEventOrchestrationIntegrationUrl(orchestrationId, id)
+	return s.client.newRequestDoContext(ctx, "DELETE", u, nil, nil, nil)
+}
+
+func (s *EventOrchestrationIntegrationService) MigrateFromOrchestration(destinationOrchestrationId string, sourceOrchestrationId string, id string) (*ListEventOrchestrationIntegrationsResponse, *Response, error) {
+	return s.MigrateFromOrchestrationContext(context.Background(), destinationOrchestrationId, sourceOrchestrationId, id)
+}
+
+func (s *EventOrchestrationIntegrationService) MigrateFromOrchestrationContext(ctx context.Context, destinationOrchestrationId string, sourceOrchestrationId string, id string) (*ListEventOrchestrationIntegrationsResponse, *Response, error) {
+	u := buildEventOrchestrationIntegrationUrl(destinationOrchestrationId, "migration")
+	v := new(ListEventOrchestrationIntegrationsResponse)
+	p := &EventOrchestrationIntegrationMigrationPayload{
+		SourceType:    "orchestration",
+		SourceId:      sourceOrchestrationId,
+		IntegrationId: id,
+	}
+
+	resp, err := s.client.newRequestDoContext(ctx, "POST", u, nil, p, v)
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v, resp, nil
+}

--- a/pagerduty/event_orchestration_integration.go
+++ b/pagerduty/event_orchestration_integration.go
@@ -43,10 +43,6 @@ func buildEventOrchestrationIntegrationUrl(orchestrationId string, lastUrlSegmen
 	return url
 }
 
-func (s *EventOrchestrationIntegrationService) List(orchestrationId string) (*ListEventOrchestrationIntegrationsResponse, *Response, error) {
-	return s.ListContext(context.Background(), orchestrationId)
-}
-
 func (s *EventOrchestrationIntegrationService) ListContext(ctx context.Context, orchestrationId string) (*ListEventOrchestrationIntegrationsResponse, *Response, error) {
 	u := buildEventOrchestrationIntegrationUrl(orchestrationId, "")
 	v := new(ListEventOrchestrationIntegrationsResponse)
@@ -58,10 +54,6 @@ func (s *EventOrchestrationIntegrationService) ListContext(ctx context.Context, 
 	}
 
 	return v, resp, nil
-}
-
-func (s *EventOrchestrationIntegrationService) Create(orchestrationId string, integration *EventOrchestrationIntegration) (*EventOrchestrationIntegration, *Response, error) {
-	return s.CreateContext(context.Background(), orchestrationId, integration)
 }
 
 func (s *EventOrchestrationIntegrationService) CreateContext(ctx context.Context, orchestrationId string, integration *EventOrchestrationIntegration) (*EventOrchestrationIntegration, *Response, error) {
@@ -78,10 +70,6 @@ func (s *EventOrchestrationIntegrationService) CreateContext(ctx context.Context
 	return v.Integration, resp, nil
 }
 
-func (s *EventOrchestrationIntegrationService) Get(orchestrationId string, id string) (*EventOrchestrationIntegration, *Response, error) {
-	return s.GetContext(context.Background(), orchestrationId, id)
-}
-
 func (s *EventOrchestrationIntegrationService) GetContext(ctx context.Context, orchestrationId string, id string) (*EventOrchestrationIntegration, *Response, error) {
 	u := buildEventOrchestrationIntegrationUrl(orchestrationId, id)
 	v := new(EventOrchestrationIntegrationPayload)
@@ -92,10 +80,6 @@ func (s *EventOrchestrationIntegrationService) GetContext(ctx context.Context, o
 	}
 
 	return v.Integration, resp, nil
-}
-
-func (s *EventOrchestrationIntegrationService) Update(orchestrationId string, id string, integration *EventOrchestrationIntegration) (*EventOrchestrationIntegration, *Response, error) {
-	return s.UpdateContext(context.Background(), orchestrationId, id, integration)
 }
 
 func (s *EventOrchestrationIntegrationService) UpdateContext(ctx context.Context, orchestrationId string, id string, integration *EventOrchestrationIntegration) (*EventOrchestrationIntegration, *Response, error) {
@@ -111,17 +95,9 @@ func (s *EventOrchestrationIntegrationService) UpdateContext(ctx context.Context
 	return v.Integration, resp, nil
 }
 
-func (s *EventOrchestrationIntegrationService) Delete(orchestrationId string, id string) (*Response, error) {
-	return s.DeleteContext(context.Background(), orchestrationId, id)
-}
-
 func (s *EventOrchestrationIntegrationService) DeleteContext(ctx context.Context, orchestrationId string, id string) (*Response, error) {
 	u := buildEventOrchestrationIntegrationUrl(orchestrationId, id)
 	return s.client.newRequestDoContext(ctx, "DELETE", u, nil, nil, nil)
-}
-
-func (s *EventOrchestrationIntegrationService) MigrateFromOrchestration(destinationOrchestrationId string, sourceOrchestrationId string, id string) (*ListEventOrchestrationIntegrationsResponse, *Response, error) {
-	return s.MigrateFromOrchestrationContext(context.Background(), destinationOrchestrationId, sourceOrchestrationId, id)
 }
 
 func (s *EventOrchestrationIntegrationService) MigrateFromOrchestrationContext(ctx context.Context, destinationOrchestrationId string, sourceOrchestrationId string, id string) (*ListEventOrchestrationIntegrationsResponse, *Response, error) {

--- a/pagerduty/event_orchestration_integration_test.go
+++ b/pagerduty/event_orchestration_integration_test.go
@@ -1,0 +1,323 @@
+package pagerduty
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestEventOrchestrationIntegrationList(t *testing.T) {
+	setup()
+	defer teardown()
+
+	oId := "a64f9c87-6adc-4f89-a64c-2fdd8cba4639"
+	url := fmt.Sprintf("%s/%s/integrations", eventOrchestrationBaseUrl, oId)
+
+	mux.HandleFunc(url, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		w.Write([]byte(`{
+			"integrations": [
+				{
+					"id": "b2c92c66-bb25-48a3-b1cb-f38b26837277",
+					"label": "My Orchestration Default Integration",
+					"parameters": {
+						"routing_key": "R0XXXXXXXXXXXXXXXXXXXXXXXXXXXXX1",
+						"type": "global"
+					}
+				},
+				{
+					"id": "b8a1f84c-418c-417c-90bb-597bf5ca7ffc",
+					"label": "My Integration 2",
+					"parameters": {
+						"routing_key": "R0XXXXXXXXXXXXXXXXXXXXXXXXXXXXX2",
+						"type": "global"
+					}
+				},
+				{
+					"id": "8e61060f-fa66-4c21-a858-9fd997c28ccc",
+					"label": "My Integration 3",
+					"parameters": {
+						"routing_key": "R0XXXXXXXXXXXXXXXXXXXXXXXXXXXXX3",
+						"type": "global"
+					}
+				}
+			],
+			"total": 3
+		}`))
+	})
+
+	resp, _, err := client.EventOrchestrationIntegrations.List(oId)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &ListEventOrchestrationIntegrationsResponse{
+		Integrations: []*EventOrchestrationIntegration{
+			{
+				ID:    "b2c92c66-bb25-48a3-b1cb-f38b26837277",
+				Label: "My Orchestration Default Integration",
+				Parameters: &EventOrchestrationIntegrationParameters{
+					RoutingKey: "R0XXXXXXXXXXXXXXXXXXXXXXXXXXXXX1",
+					Type:       "global",
+				},
+			},
+			{
+				ID:    "b8a1f84c-418c-417c-90bb-597bf5ca7ffc",
+				Label: "My Integration 2",
+				Parameters: &EventOrchestrationIntegrationParameters{
+					RoutingKey: "R0XXXXXXXXXXXXXXXXXXXXXXXXXXXXX2",
+					Type:       "global",
+				},
+			},
+			{
+				ID:    "8e61060f-fa66-4c21-a858-9fd997c28ccc",
+				Label: "My Integration 3",
+				Parameters: &EventOrchestrationIntegrationParameters{
+					RoutingKey: "R0XXXXXXXXXXXXXXXXXXXXXXXXXXXXX3",
+					Type:       "global",
+				},
+			},
+		},
+		Total: 3,
+	}
+
+	if !reflect.DeepEqual(resp, want) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp, want)
+	}
+}
+
+func TestEventOrchestrationIntegrationCreate(t *testing.T) {
+	setup()
+	defer teardown()
+	oId := "a64f9c87-6adc-4f89-a64c-2fdd8cba4639"
+	input := &EventOrchestrationIntegration{
+		Label: "My Integration",
+	}
+	url := fmt.Sprintf("%s/%s/integrations", eventOrchestrationBaseUrl, oId)
+
+	mux.HandleFunc(url, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		v := new(EventOrchestrationIntegrationPayload)
+		json.NewDecoder(r.Body).Decode(v)
+		if !reflect.DeepEqual(v.Integration, input) {
+			t.Errorf("Request body = %+v, want %+v", v, input)
+		}
+		w.Write([]byte(`{
+			"integration": {
+				"id": "b8a1f84c-418c-417c-90bb-597bf5ca7ffc",
+				"label": "My Integration",
+				"parameters": {
+					"routing_key": "R0XXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+					"type": "global"
+				}
+			}
+		}`))
+	})
+
+	resp, _, err := client.EventOrchestrationIntegrations.Create(oId, input)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &EventOrchestrationIntegration{
+		ID:    "b8a1f84c-418c-417c-90bb-597bf5ca7ffc",
+		Label: "My Integration",
+		Parameters: &EventOrchestrationIntegrationParameters{
+			RoutingKey: "R0XXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+			Type:       "global",
+		},
+	}
+
+	if !reflect.DeepEqual(resp, want) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp, want)
+	}
+}
+
+func TestEventOrchestrationIntegrationGet(t *testing.T) {
+	setup()
+	defer teardown()
+
+	oId := "a64f9c87-6adc-4f89-a64c-2fdd8cba4639"
+	id := "b8a1f84c-418c-417c-90bb-597bf5ca7ffc"
+	url := fmt.Sprintf("%s/%s/integrations/%s", eventOrchestrationBaseUrl, oId, id)
+
+	mux.HandleFunc(url, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		w.Write([]byte(`{
+			"integration": {
+				"id": "b8a1f84c-418c-417c-90bb-597bf5ca7ffc",
+				"label": "My Integration",
+				"parameters": {
+					"routing_key": "R0XXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+					"type": "global"
+				}
+			}
+		}`))
+	})
+
+	resp, _, err := client.EventOrchestrationIntegrations.Get(oId, id)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &EventOrchestrationIntegration{
+		ID:    "b8a1f84c-418c-417c-90bb-597bf5ca7ffc",
+		Label: "My Integration",
+		Parameters: &EventOrchestrationIntegrationParameters{
+			RoutingKey: "R0XXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+			Type:       "global",
+		},
+	}
+
+	if !reflect.DeepEqual(resp, want) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp, want)
+	}
+}
+
+func TestEventOrchestrationIntegrationUpdate(t *testing.T) {
+	setup()
+	defer teardown()
+	oId := "a64f9c87-6adc-4f89-a64c-2fdd8cba4639"
+	id := "b8a1f84c-418c-417c-90bb-597bf5ca7ffc"
+	input := &EventOrchestrationIntegration{
+		Label: "My Updated Integration",
+	}
+	url := fmt.Sprintf("%s/%s/integrations/%s", eventOrchestrationBaseUrl, oId, id)
+
+	mux.HandleFunc(url, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		v := new(EventOrchestrationIntegrationPayload)
+		json.NewDecoder(r.Body).Decode(v)
+		if !reflect.DeepEqual(v.Integration, input) {
+			t.Errorf("Request body = %+v, want %+v", v, input)
+		}
+		w.Write([]byte(`{
+			"integration": {
+				"id": "b8a1f84c-418c-417c-90bb-597bf5ca7ffc",
+				"label": "My Updated Integration",
+				"parameters": {
+					"routing_key": "R0XXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+					"type": "global"
+				}
+			}
+		}`))
+	})
+
+	resp, _, err := client.EventOrchestrationIntegrations.Update(oId, id, input)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &EventOrchestrationIntegration{
+		ID:    "b8a1f84c-418c-417c-90bb-597bf5ca7ffc",
+		Label: "My Updated Integration",
+		Parameters: &EventOrchestrationIntegrationParameters{
+			RoutingKey: "R0XXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+			Type:       "global",
+		},
+	}
+
+	if !reflect.DeepEqual(resp, want) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp, want)
+	}
+}
+
+func TestEventOrchestrationIntegrationDelete(t *testing.T) {
+	setup()
+	defer teardown()
+
+	oId := "a64f9c87-6adc-4f89-a64c-2fdd8cba4639"
+	id := "b8a1f84c-418c-417c-90bb-597bf5ca7ffc"
+	url := fmt.Sprintf("%s/%s/integrations/%s", eventOrchestrationBaseUrl, oId, id)
+
+	mux.HandleFunc(url, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	if _, err := client.EventOrchestrationIntegrations.Delete(oId, id); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestEventOrchestrationIntegrationMigrate(t *testing.T) {
+	setup()
+	defer teardown()
+	soId := "a64f9c87-6adc-4f89-a64c-2fdd8cba4639"
+	doId := "a99a20bd-7699-4722-8bef-b48c2fcac116"
+	id := "b8a1f84c-418c-417c-90bb-597bf5ca7ffc"
+	input := &EventOrchestrationIntegrationMigrationPayload{
+		SourceType:    "orchestration",
+		SourceId:      soId,
+		IntegrationId: id,
+	}
+	url := fmt.Sprintf("%s/%s/integrations/migration", eventOrchestrationBaseUrl, doId)
+
+	mux.HandleFunc(url, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		v := new(EventOrchestrationIntegrationMigrationPayload)
+		json.NewDecoder(r.Body).Decode(v)
+		if !reflect.DeepEqual(v, input) {
+			t.Errorf("Request body = %+v, want %+v", v, input)
+		}
+		w.Write([]byte(`{
+			"integrations": [
+				{
+					"id": "b2c92c66-bb25-48a3-b1cb-f38b26837277",
+					"label": "My Orchestration Default Integration",
+					"parameters": {
+						"routing_key": "R0XXXXXXXXXXXXXXXXXXXXXXXXXXXXX1",
+						"type": "global"
+					}
+				},
+				{
+					"id": "b8a1f84c-418c-417c-90bb-597bf5ca7ffc",
+					"label": "Source Orchestration Integraton",
+					"parameters": {
+						"routing_key": "R0XXXXXXXXXXXXXXXXXXXXXXXXXXXXX2",
+						"type": "global"
+					}
+				}
+			],
+			"total": 2
+		}`))
+	})
+
+	resp, _, err := client.EventOrchestrationIntegrations.MigrateFromOrchestration(doId, soId, id)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &ListEventOrchestrationIntegrationsResponse{
+		Integrations: []*EventOrchestrationIntegration{
+			{
+				ID:    "b2c92c66-bb25-48a3-b1cb-f38b26837277",
+				Label: "My Orchestration Default Integration",
+				Parameters: &EventOrchestrationIntegrationParameters{
+					RoutingKey: "R0XXXXXXXXXXXXXXXXXXXXXXXXXXXXX1",
+					Type:       "global",
+				},
+			},
+			{
+				ID:    "b8a1f84c-418c-417c-90bb-597bf5ca7ffc",
+				Label: "Source Orchestration Integraton",
+				Parameters: &EventOrchestrationIntegrationParameters{
+					RoutingKey: "R0XXXXXXXXXXXXXXXXXXXXXXXXXXXXX2",
+					Type:       "global",
+				},
+			},
+		},
+		Total: 2,
+	}
+
+	if !reflect.DeepEqual(resp, want) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp, want)
+	}
+}

--- a/pagerduty/event_orchestration_integration_test.go
+++ b/pagerduty/event_orchestration_integration_test.go
@@ -1,6 +1,7 @@
 package pagerduty
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -48,7 +49,7 @@ func TestEventOrchestrationIntegrationList(t *testing.T) {
 		}`))
 	})
 
-	resp, _, err := client.EventOrchestrationIntegrations.List(oId)
+	resp, _, err := client.EventOrchestrationIntegrations.ListContext(context.Background(), oId)
 
 	if err != nil {
 		t.Fatal(err)
@@ -117,7 +118,7 @@ func TestEventOrchestrationIntegrationCreate(t *testing.T) {
 		}`))
 	})
 
-	resp, _, err := client.EventOrchestrationIntegrations.Create(oId, input)
+	resp, _, err := client.EventOrchestrationIntegrations.CreateContext(context.Background(), oId, input)
 
 	if err != nil {
 		t.Fatal(err)
@@ -159,7 +160,7 @@ func TestEventOrchestrationIntegrationGet(t *testing.T) {
 		}`))
 	})
 
-	resp, _, err := client.EventOrchestrationIntegrations.Get(oId, id)
+	resp, _, err := client.EventOrchestrationIntegrations.GetContext(context.Background(), oId, id)
 
 	if err != nil {
 		t.Fatal(err)
@@ -208,7 +209,7 @@ func TestEventOrchestrationIntegrationUpdate(t *testing.T) {
 		}`))
 	})
 
-	resp, _, err := client.EventOrchestrationIntegrations.Update(oId, id, input)
+	resp, _, err := client.EventOrchestrationIntegrations.UpdateContext(context.Background(), oId, id, input)
 
 	if err != nil {
 		t.Fatal(err)
@@ -241,7 +242,7 @@ func TestEventOrchestrationIntegrationDelete(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	if _, err := client.EventOrchestrationIntegrations.Delete(oId, id); err != nil {
+	if _, err := client.EventOrchestrationIntegrations.DeleteContext(context.Background(), oId, id); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -289,7 +290,7 @@ func TestEventOrchestrationIntegrationMigrate(t *testing.T) {
 		}`))
 	})
 
-	resp, _, err := client.EventOrchestrationIntegrations.MigrateFromOrchestration(doId, soId, id)
+	resp, _, err := client.EventOrchestrationIntegrations.MigrateFromOrchestrationContext(context.Background(), doId, soId, id)
 
 	if err != nil {
 		t.Fatal(err)

--- a/pagerduty/event_orchestration_path.go
+++ b/pagerduty/event_orchestration_path.go
@@ -50,7 +50,7 @@ type EventOrchestrationPathRuleCondition struct {
 // Service: https://developer.pagerduty.com/api-reference/179537b835e2d-get-the-service-orchestration-for-a-service
 // Unrouted: https://developer.pagerduty.com/api-reference/70aa1139e1013-get-the-unrouted-orchestration-for-a-global-event-orchestration
 type EventOrchestrationPathRuleActions struct {
-	DropEvent									 bool																								`json:"drop_event"`
+	DropEvent                  bool                                               `json:"drop_event"`
 	RouteTo                    string                                             `json:"route_to"`
 	Suppress                   bool                                               `json:"suppress"`
 	Suspend                    *int                                               `json:"suspend"`
@@ -104,16 +104,16 @@ type EventOrchestrationPathCatchAll struct {
 }
 
 type EventOrchestrationPathWarning struct {
-	Feature string `json:"feature"`
+	Feature     string `json:"feature"`
 	FeatureType string `json:"feature_type"`
-	Message string `json:"message"`
-	RuleId string `json:"rule_id"`
+	Message     string `json:"message"`
+	RuleId      string `json:"rule_id"`
 	WarningType string `json:"warning_type"`
 }
 
 type EventOrchestrationPathPayload struct {
-	OrchestrationPath *EventOrchestrationPath `json:"orchestration_path,omitempty"`
-	Warnings []*EventOrchestrationPathWarning `json:"warnings"`
+	OrchestrationPath *EventOrchestrationPath          `json:"orchestration_path,omitempty"`
+	Warnings          []*EventOrchestrationPathWarning `json:"warnings"`
 }
 
 const PathTypeGlobal string = "global"

--- a/pagerduty/event_orchestration_path.go
+++ b/pagerduty/event_orchestration_path.go
@@ -101,8 +101,17 @@ type EventOrchestrationPathCatchAll struct {
 	Actions *EventOrchestrationPathRuleActions `json:"actions,omitempty"`
 }
 
+type EventOrchestrationPathWarning struct {
+	Feature string `json:"feature"`
+	FeatureType string `json:"feature_type"`
+	Message string `json:"message"`
+	RuleId string `json:"rule_id"`
+	WarningType string `json:"warning_type"`
+}
+
 type EventOrchestrationPathPayload struct {
 	OrchestrationPath *EventOrchestrationPath `json:"orchestration_path,omitempty"`
+	Warnings []*EventOrchestrationPathWarning `json:"warnings"`
 }
 
 const PathTypeRouter string = "router"
@@ -151,7 +160,7 @@ func (s *EventOrchestrationPathService) GetServiceActiveStatus(id string) (*Even
 }
 
 // Update for EventOrchestrationPath
-func (s *EventOrchestrationPathService) Update(id string, pathType string, orchestration_path *EventOrchestrationPath) (*EventOrchestrationPath, *Response, error) {
+func (s *EventOrchestrationPathService) Update(id string, pathType string, orchestration_path *EventOrchestrationPath) (*EventOrchestrationPathPayload, *Response, error) {
 	u := orchestrationPathUrlBuilder(id, pathType)
 	v := new(EventOrchestrationPathPayload)
 	p := EventOrchestrationPathPayload{OrchestrationPath: orchestration_path}
@@ -161,7 +170,7 @@ func (s *EventOrchestrationPathService) Update(id string, pathType string, orche
 		return nil, nil, err
 	}
 
-	return v.OrchestrationPath, resp, nil
+	return v, resp, nil
 }
 
 // UpdateServiceActiveStatus for EventOrchestrationPath

--- a/pagerduty/event_orchestration_path.go
+++ b/pagerduty/event_orchestration_path.go
@@ -45,10 +45,12 @@ type EventOrchestrationPathRuleCondition struct {
 }
 
 // See the full list of supported actions for path types:
+// Global: TODO
 // Router: https://developer.pagerduty.com/api-reference/f0fae270c70b3-get-the-router-for-a-global-event-orchestration
 // Service: https://developer.pagerduty.com/api-reference/179537b835e2d-get-the-service-orchestration-for-a-service
 // Unrouted: https://developer.pagerduty.com/api-reference/70aa1139e1013-get-the-unrouted-orchestration-for-a-global-event-orchestration
 type EventOrchestrationPathRuleActions struct {
+	DropEvent									 bool																								`json:"drop_event"`
 	RouteTo                    string                                             `json:"route_to"`
 	Suppress                   bool                                               `json:"suppress"`
 	Suspend                    *int                                               `json:"suspend"`
@@ -114,21 +116,17 @@ type EventOrchestrationPathPayload struct {
 	Warnings []*EventOrchestrationPathWarning `json:"warnings"`
 }
 
+const PathTypeGlobal string = "global"
 const PathTypeRouter string = "router"
 const PathTypeService string = "service"
 const PathTypeUnrouted string = "unrouted"
 
 func orchestrationPathUrlBuilder(id string, pathType string) string {
-	switch {
-	case pathType == PathTypeService:
+	if pathType == PathTypeService {
 		return fmt.Sprintf("%s/services/%s", eventOrchestrationBaseUrl, id)
-	case pathType == PathTypeUnrouted:
-		return fmt.Sprintf("%s/%s/unrouted", eventOrchestrationBaseUrl, id)
-	case pathType == PathTypeRouter:
-		return fmt.Sprintf("%s/%s/router", eventOrchestrationBaseUrl, id)
-	default:
-		return ""
 	}
+
+	return fmt.Sprintf("%s/%s/%s", eventOrchestrationBaseUrl, id, pathType)
 }
 
 // Get for EventOrchestrationPath

--- a/pagerduty/event_orchestration_path.go
+++ b/pagerduty/event_orchestration_path.go
@@ -1,6 +1,7 @@
 package pagerduty
 
 import (
+	"context"
 	"fmt"
 )
 
@@ -131,10 +132,14 @@ func orchestrationPathUrlBuilder(id string, pathType string) string {
 
 // Get for EventOrchestrationPath
 func (s *EventOrchestrationPathService) Get(id string, pathType string) (*EventOrchestrationPath, *Response, error) {
+	return s.GetContext(context.Background(), id, pathType)
+}
+
+func (s *EventOrchestrationPathService) GetContext(ctx context.Context, id string, pathType string) (*EventOrchestrationPath, *Response, error) {
 	u := orchestrationPathUrlBuilder(id, pathType)
 	v := new(EventOrchestrationPathPayload)
 
-	resp, err := s.client.newRequestDo("GET", u, nil, nil, &v)
+	resp, err := s.client.newRequestDoContext(ctx, "GET", u, nil, nil, &v)
 
 	if err != nil {
 		return nil, nil, err
@@ -144,11 +149,11 @@ func (s *EventOrchestrationPathService) Get(id string, pathType string) (*EventO
 }
 
 // GetServiceActiveStatus for EventOrchestrationPath
-func (s *EventOrchestrationPathService) GetServiceActiveStatus(id string) (*EventOrchestrationPathServiceActiveStatus, *Response, error) {
+func (s *EventOrchestrationPathService) GetServiceActiveStatusContext(ctx context.Context, id string) (*EventOrchestrationPathServiceActiveStatus, *Response, error) {
 	u := fmt.Sprintf("%s/services/%s/active", eventOrchestrationBaseUrl, id)
 	v := new(EventOrchestrationPathServiceActiveStatus)
 
-	resp, err := s.client.newRequestDo("GET", u, nil, nil, &v)
+	resp, err := s.client.newRequestDoContext(ctx, "GET", u, nil, nil, &v)
 
 	if err != nil {
 		return nil, nil, err
@@ -158,12 +163,16 @@ func (s *EventOrchestrationPathService) GetServiceActiveStatus(id string) (*Even
 }
 
 // Update for EventOrchestrationPath
-func (s *EventOrchestrationPathService) Update(id string, pathType string, orchestration_path *EventOrchestrationPath) (*EventOrchestrationPathPayload, *Response, error) {
+func (s *EventOrchestrationPathService) Update(id string, pathType string, orchestrationPath *EventOrchestrationPath) (*EventOrchestrationPathPayload, *Response, error) {
+	return s.UpdateContext(context.Background(), id, pathType, orchestrationPath)
+}
+
+func (s *EventOrchestrationPathService) UpdateContext(ctx context.Context, id string, pathType string, orchestrationPath *EventOrchestrationPath) (*EventOrchestrationPathPayload, *Response, error) {
 	u := orchestrationPathUrlBuilder(id, pathType)
 	v := new(EventOrchestrationPathPayload)
-	p := EventOrchestrationPathPayload{OrchestrationPath: orchestration_path}
+	p := EventOrchestrationPathPayload{OrchestrationPath: orchestrationPath}
 
-	resp, err := s.client.newRequestDo("PUT", u, nil, p, &v)
+	resp, err := s.client.newRequestDoContext(ctx, "PUT", u, nil, p, &v)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -172,12 +181,12 @@ func (s *EventOrchestrationPathService) Update(id string, pathType string, orche
 }
 
 // UpdateServiceActiveStatus for EventOrchestrationPath
-func (s *EventOrchestrationPathService) UpdateServiceActiveStatus(id string, isActive bool) (*EventOrchestrationPathServiceActiveStatus, *Response, error) {
+func (s *EventOrchestrationPathService) UpdateServiceActiveStatusContext(ctx context.Context, id string, isActive bool) (*EventOrchestrationPathServiceActiveStatus, *Response, error) {
 	u := fmt.Sprintf("%s/services/%s/active", eventOrchestrationBaseUrl, id)
 	v := new(EventOrchestrationPathServiceActiveStatus)
 	p := EventOrchestrationPathServiceActiveStatus{Active: isActive}
 
-	resp, err := s.client.newRequestDo("PUT", u, nil, p, &v)
+	resp, err := s.client.newRequestDoContext(ctx, "PUT", u, nil, p, &v)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pagerduty/event_orchestration_path.go
+++ b/pagerduty/event_orchestration_path.go
@@ -46,7 +46,7 @@ type EventOrchestrationPathRuleCondition struct {
 }
 
 // See the full list of supported actions for path types:
-// Global: TODO
+// Global: https://developer.pagerduty.com/api-reference/28317f3c2bdfd-get-the-global-orchestration-for-an-event-orchestration
 // Router: https://developer.pagerduty.com/api-reference/f0fae270c70b3-get-the-router-for-a-global-event-orchestration
 // Service: https://developer.pagerduty.com/api-reference/179537b835e2d-get-the-service-orchestration-for-a-service
 // Unrouted: https://developer.pagerduty.com/api-reference/70aa1139e1013-get-the-unrouted-orchestration-for-a-global-event-orchestration

--- a/pagerduty/event_orchestration_path_test.go
+++ b/pagerduty/event_orchestration_path_test.go
@@ -199,34 +199,37 @@ func TestEventOrchestrationPathRouterPathUpdate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	want := &EventOrchestrationPath{
-		Type: "router",
-		Parent: &EventOrchestrationPathReference{
-			ID:   "E-ORC-1",
-			Self: "https://api.pagerduty.com/event_orchestrations/E-ORC-1",
-			Type: "event_orchestration_reference",
-		},
-		Sets: []*EventOrchestrationPathSet{
-			{
-				ID: "start",
-				Rules: []*EventOrchestrationPathRule{
-					{
-						Actions: &EventOrchestrationPathRuleActions{
-							RouteTo: "P3ZQXDF",
-						},
-						Conditions: []*EventOrchestrationPathRuleCondition{
-							{
-								Expression: "event.summary matches part 'orca'",
+	want := &EventOrchestrationPathPayload{
+		OrchestrationPath: &EventOrchestrationPath{
+			Type: "router",
+			Parent: &EventOrchestrationPathReference{
+				ID:   "E-ORC-1",
+				Self: "https://api.pagerduty.com/event_orchestrations/E-ORC-1",
+				Type: "event_orchestration_reference",
+			},
+			Sets: []*EventOrchestrationPathSet{
+				{
+					ID: "start",
+					Rules: []*EventOrchestrationPathRule{
+						{
+							Actions: &EventOrchestrationPathRuleActions{
+								RouteTo: "P3ZQXDF",
 							},
-							{
-								Expression: "event.summary matches part 'humpback'",
+							Conditions: []*EventOrchestrationPathRuleCondition{
+								{
+									Expression: "event.summary matches part 'orca'",
+								},
+								{
+									Expression: "event.summary matches part 'humpback'",
+								},
 							},
+							ID: "E-ORC-RULE-1",
 						},
-						ID: "E-ORC-RULE-1",
 					},
 				},
 			},
 		},
+		Warnings: nil,
 	}
 
 	if !reflect.DeepEqual(resp, want) {
@@ -261,7 +264,13 @@ func TestEventOrchestrationPathUnroutedPathUpdate(t *testing.T) {
 		if !reflect.DeepEqual(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
-		w.Write([]byte(`{"orchestration_path": { "type": "unrouted", "parent": { "id": "E-ORC-1", "self": "https://api.pagerduty.com/event_orchestrations/E-ORC-1", "type": "event_orchestration_reference" }, "sets": [ { "id": "start", "rules": [ { "actions": { "route_to": "P3ZQXDF" }, "conditions": [ { "expression": "event.summary matches part 'orca'" }, { "expression": "event.summary matches part 'humpback'" } ], "id": "E-ORC-RULE-1"}]}]}}`))
+		w.Write([]byte(`{
+			"orchestration_path": { "type": "unrouted", "parent": { "id": "E-ORC-1", "self": "https://api.pagerduty.com/event_orchestrations/E-ORC-1", "type": "event_orchestration_reference" }, "sets": [ { "id": "start", "rules": [ { "actions": { "route_to": "P3ZQXDF" }, "conditions": [ { "expression": "event.summary matches part 'orca'" }, { "expression": "event.summary matches part 'humpback'" } ], "id": "E-ORC-RULE-1"}]}]},
+			"warnings": [
+				{"feature": "variables", "feature_type": "actions", "message": "Message 1", "rule_id": "abcd001", "warning_type": "forbidden_feature"},
+				{"feature": "extractions", "feature_type": "actions", "message": "Message 2", "rule_id": "abcd002", "warning_type": "forbidden_feature"}
+			]
+		}`))
 	})
 
 	resp, _, err := client.EventOrchestrationPaths.Update("E-ORC-1", PathTypeUnrouted, input)
@@ -269,32 +278,50 @@ func TestEventOrchestrationPathUnroutedPathUpdate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	want := &EventOrchestrationPath{
-		Type: "unrouted",
-		Parent: &EventOrchestrationPathReference{
-			ID:   "E-ORC-1",
-			Self: "https://api.pagerduty.com/event_orchestrations/E-ORC-1",
-			Type: "event_orchestration_reference",
-		},
-		Sets: []*EventOrchestrationPathSet{
-			{
-				ID: "start",
-				Rules: []*EventOrchestrationPathRule{
-					{
-						Actions: &EventOrchestrationPathRuleActions{
-							RouteTo: "P3ZQXDF",
-						},
-						Conditions: []*EventOrchestrationPathRuleCondition{
-							{
-								Expression: "event.summary matches part 'orca'",
+	want := &EventOrchestrationPathPayload{
+		OrchestrationPath: &EventOrchestrationPath{
+			Type: "unrouted",
+			Parent: &EventOrchestrationPathReference{
+				ID:   "E-ORC-1",
+				Self: "https://api.pagerduty.com/event_orchestrations/E-ORC-1",
+				Type: "event_orchestration_reference",
+			},
+			Sets: []*EventOrchestrationPathSet{
+				{
+					ID: "start",
+					Rules: []*EventOrchestrationPathRule{
+						{
+							Actions: &EventOrchestrationPathRuleActions{
+								RouteTo: "P3ZQXDF",
 							},
-							{
-								Expression: "event.summary matches part 'humpback'",
+							Conditions: []*EventOrchestrationPathRuleCondition{
+								{
+									Expression: "event.summary matches part 'orca'",
+								},
+								{
+									Expression: "event.summary matches part 'humpback'",
+								},
 							},
+							ID: "E-ORC-RULE-1",
 						},
-						ID: "E-ORC-RULE-1",
 					},
 				},
+			},
+		},
+		Warnings: []*EventOrchestrationPathWarning{
+			&EventOrchestrationPathWarning{
+				Feature: "variables",
+				FeatureType: "actions",
+				Message: "Message 1",
+				RuleId: "abcd001",
+				WarningType: "forbidden_feature",
+			},
+			&EventOrchestrationPathWarning{
+				Feature: "extractions",
+				FeatureType: "actions",
+				Message: "Message 2",
+				RuleId: "abcd002",
+				WarningType: "forbidden_feature",
 			},
 		},
 	}
@@ -361,7 +388,10 @@ func TestEventOrchestrationPathServicePathUpdate(t *testing.T) {
 		if !reflect.DeepEqual(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
-		w.Write([]byte(`{"orchestration_path": { "type": "service", "parent": { "id": "E-ORC-1", "self": "https://api.pagerduty.com/event_orchestrations/E-ORC-1", "type": "event_orchestration_reference" }, "sets": [ { "id": "start", "rules": [ { "actions": { "route_to": "P3ZQXDF" }, "conditions": [ { "expression": "event.summary matches part 'orca'" }, { "expression": "event.summary matches part 'humpback'" } ], "id": "E-ORC-RULE-1"}]}]}}`))
+		w.Write([]byte(`{
+			"orchestration_path": { "type": "service", "parent": { "id": "E-ORC-1", "self": "https://api.pagerduty.com/event_orchestrations/E-ORC-1", "type": "event_orchestration_reference" }, "sets": [ { "id": "start", "rules": [ { "actions": { "route_to": "P3ZQXDF" }, "conditions": [ { "expression": "event.summary matches part 'orca'" }, { "expression": "event.summary matches part 'humpback'" } ], "id": "E-ORC-RULE-1"}]}]},
+			"warnings": []
+		}`))
 	})
 
 	resp, _, err := client.EventOrchestrationPaths.Update("P3ZQXDF", PathTypeService, input)
@@ -369,34 +399,37 @@ func TestEventOrchestrationPathServicePathUpdate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	want := &EventOrchestrationPath{
-		Type: "service",
-		Parent: &EventOrchestrationPathReference{
-			ID:   "E-ORC-1",
-			Self: "https://api.pagerduty.com/event_orchestrations/E-ORC-1",
-			Type: "event_orchestration_reference",
-		},
-		Sets: []*EventOrchestrationPathSet{
-			{
-				ID: "start",
-				Rules: []*EventOrchestrationPathRule{
-					{
-						Actions: &EventOrchestrationPathRuleActions{
-							RouteTo: "P3ZQXDF",
-						},
-						Conditions: []*EventOrchestrationPathRuleCondition{
-							{
-								Expression: "event.summary matches part 'orca'",
+	want := &EventOrchestrationPathPayload{
+		OrchestrationPath: &EventOrchestrationPath{
+			Type: "service",
+			Parent: &EventOrchestrationPathReference{
+				ID:   "E-ORC-1",
+				Self: "https://api.pagerduty.com/event_orchestrations/E-ORC-1",
+				Type: "event_orchestration_reference",
+			},
+			Sets: []*EventOrchestrationPathSet{
+				{
+					ID: "start",
+					Rules: []*EventOrchestrationPathRule{
+						{
+							Actions: &EventOrchestrationPathRuleActions{
+								RouteTo: "P3ZQXDF",
 							},
-							{
-								Expression: "event.summary matches part 'humpback'",
+							Conditions: []*EventOrchestrationPathRuleCondition{
+								{
+									Expression: "event.summary matches part 'orca'",
+								},
+								{
+									Expression: "event.summary matches part 'humpback'",
+								},
 							},
+							ID: "E-ORC-RULE-1",
 						},
-						ID: "E-ORC-RULE-1",
 					},
 				},
 			},
 		},
+		Warnings: []*EventOrchestrationPathWarning{},
 	}
 
 	if !reflect.DeepEqual(resp, want) {

--- a/pagerduty/event_orchestration_path_test.go
+++ b/pagerduty/event_orchestration_path_test.go
@@ -8,7 +8,92 @@ import (
 	"testing"
 )
 
-func TestEventOrchestrationPathGetRouterPath(t *testing.T) {
+func TestEventOrchestrationPathGlobalGet(t *testing.T) {
+	setup()
+	defer teardown()
+
+	var url = fmt.Sprintf("%s/E-ORC-1/global", eventOrchestrationBaseUrl)
+	mux.HandleFunc(url, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		w.Write([]byte(`{
+			"orchestration_path": {
+				"catch_all": {
+					"actions": {}
+				},
+				"created_at": "2022-07-13T20:44:58Z",
+				"created_by": {
+					"id": "P8B9WR7",
+					"self": "https://api.pagerduty.com/users/P8B9WR7",
+					"type": "user_reference"
+				},
+				"parent": {
+					"id": "E-ORC-1",
+					"self": "https://api.pagerduty.com/event_orchestrations/E-ORC-1",
+					"type": "event_orchestration_reference"
+				},
+				"self": "https://api.pagerduty.com/event_orchestrations/E-ORC-1/global",
+				"sets": [
+					{
+						"id": "start",
+						"rules": []
+					}
+				],
+				"type": "global",
+				"updated_at": "2022-12-15T13:57:08Z",
+				"updated_by": {
+					"id": "P8B9WR8",
+					"self": "https://api.pagerduty.com/users/P8B9WR8",
+					"type": "user_reference"
+				},
+				"version": "Abcd.1234"
+			}
+		}`))
+	})	
+
+	resp, _, err := client.EventOrchestrationPaths.Get("E-ORC-1", PathTypeGlobal)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &EventOrchestrationPath{
+		CatchAll: &EventOrchestrationPathCatchAll{
+			Actions: &EventOrchestrationPathRuleActions{},
+		},
+		CreatedAt: "2022-07-13T20:44:58Z",
+		CreatedBy: &EventOrchestrationPathReference{
+			ID:   "P8B9WR7",
+			Self: "https://api.pagerduty.com/users/P8B9WR7",
+			Type: "user_reference",
+		},
+		Parent: &EventOrchestrationPathReference{
+			ID:   "E-ORC-1",
+			Self: "https://api.pagerduty.com/event_orchestrations/E-ORC-1",
+			Type: "event_orchestration_reference",
+		},
+		Self: "https://api.pagerduty.com/event_orchestrations/E-ORC-1/global",
+		Sets: []*EventOrchestrationPathSet{
+			{
+				ID: "start",
+				Rules: []*EventOrchestrationPathRule{},
+			},
+		},
+		Type: "global",
+		UpdatedAt: "2022-12-15T13:57:08Z",
+		UpdatedBy: &EventOrchestrationPathReference{
+			ID:   "P8B9WR8",
+			Self: "https://api.pagerduty.com/users/P8B9WR8",
+			Type: "user_reference",
+		},
+		Version: "Abcd.1234",
+	}
+
+	if !reflect.DeepEqual(resp, want) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp, want)
+	}
+}
+
+func TestEventOrchestrationPathRouterGet(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -51,7 +136,7 @@ func TestEventOrchestrationPathGetRouterPath(t *testing.T) {
 	}
 }
 
-func TestEventOrchestrationPathGetUnroutedPath(t *testing.T) {
+func TestEventOrchestrationPathUnroutedGet(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -94,7 +179,7 @@ func TestEventOrchestrationPathGetUnroutedPath(t *testing.T) {
 	}
 }
 
-func TestEventOrchestrationPathGetServicePath(t *testing.T) {
+func TestEventOrchestrationPathServiceGet(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -164,7 +249,225 @@ func TestEventOrchestrationPathGetServiceActiveStatus(t *testing.T) {
 	}
 }
 
-func TestEventOrchestrationPathRouterPathUpdate(t *testing.T) {
+func TestEventOrchestrationPathGlobalUpdate(t *testing.T) {
+	setup()
+	defer teardown()
+	input := &EventOrchestrationPath{
+		CatchAll: &EventOrchestrationPathCatchAll{
+			Actions: &EventOrchestrationPathRuleActions{
+				Suppress: true,
+			},
+		},
+		Sets: []*EventOrchestrationPathSet{
+			{
+				ID: "start",
+				Rules: []*EventOrchestrationPathRule{
+					{
+						Actions: &EventOrchestrationPathRuleActions{
+							DropEvent: true,
+						},
+						Conditions: []*EventOrchestrationPathRuleCondition{
+							{
+								Expression: "event.summary matches part '[TEST]'",
+							},
+						},
+						ID: "240790f7",
+						Label: "drop test events",
+					},
+					{
+						Actions: &EventOrchestrationPathRuleActions{
+							AutomationActions: []*EventOrchestrationPathAutomationAction{
+								{
+									AutoSend: true,
+									Headers: []*EventOrchestrationPathAutomationActionObject{
+										{
+											Key: "x-header-1",
+											Value: "h-one",
+										},
+										{
+											Key: "x-header-2",
+											Value: "h-two",
+										},
+									},
+									Name: "test webhook",
+									Parameters: []*EventOrchestrationPathAutomationActionObject{
+										{
+											Key: "hostname",
+											Value: "{{variables.hostname}}",
+										},
+										{
+											Key: "info",
+											Value: "{{event.summary}}",
+										},
+									},
+									Url: "https://test.com",
+								},
+							},
+							EventAction: "trigger",
+							Extractions: []*EventOrchestrationPathActionExtractions{
+								{
+									Target: "event.summary",
+									Template: "{{event.summary}}, hostname: {{variables.hostname}}",
+								},
+							},
+							Priority: "PCMUB6F",
+							RouteTo: "7589a1b9",
+							Severity: "warning",
+							Variables: []*EventOrchestrationPathActionVariables{
+								{
+									Name: "hostname",
+									Path: "event.source",
+									Type: "regex",
+									Value: ".*",
+								},
+							},
+						},
+						Conditions: []*EventOrchestrationPathRuleCondition{
+							{
+								Expression: "now in Mon,Tue,Wed,Thu,Fri 08:00:00 to 18:00:00 America/Los_Angeles",
+							},
+						},
+						ID: "4ad2c1be",
+						Label: "business hours",
+					},
+				},
+			},
+			{
+				ID: "7589a1b9",
+				Rules: []*EventOrchestrationPathRule{
+					{
+						Actions: &EventOrchestrationPathRuleActions{
+							Annotate: "received more than 10 events over 5 minutes",
+						},
+						Conditions: []*EventOrchestrationPathRuleCondition{
+							{
+								Expression: "trigger_count over 5 minute > 10",
+							},
+						},
+						ID: "fed68019",
+						Label: "too many events",
+					},
+				},
+			},
+		},
+	}
+
+	var url = fmt.Sprintf("%s/E-ORC-1/global", eventOrchestrationBaseUrl)
+
+	mux.HandleFunc(url, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		v := new(EventOrchestrationPathPayload)
+		json.NewDecoder(r.Body).Decode(v)
+		if !reflect.DeepEqual(v.OrchestrationPath, input) {
+			t.Errorf("Request body = %+v, want %+v", v, input)
+		}
+		w.Write([]byte(`{
+			"orchestration_path": {
+				"catch_all": {"actions": {"suppress": true}},
+				"created_at": "2022-07-13T20:44:58Z",
+				"created_by": {"id": "P8B9WR7", "self": "https://api.pagerduty.com/users/P8B9WR7", "type": "user_reference"},
+				"parent": {
+					"id": "E-ORC-1",
+					"self": "https://api.pagerduty.com/event_orchestrations/E-ORC-1",
+					"type": "event_orchestration_reference"
+				},
+				"self": "https://api.pagerduty.com/event_orchestrations/E-ORC-1/global",
+				"sets": [
+					{
+						"id": "start",
+						"rules": [
+							{
+								"actions": {"drop_event": true},
+								"conditions": [{"expression": "event.summary matches part '[TEST]'"}],
+								"id": "240790f7",
+								"label": "drop test events"
+							},
+							{
+								"actions": {
+									"automation_actions": [
+										{
+											"auto_send": true,
+											"headers": [{"key": "x-header-1", "value": "h-one"}, {"key": "x-header-2","value": "h-two"}],
+											"name": "test webhook",
+											"parameters": [{"key": "hostname", "value": "{{variables.hostname}}"}, {"key": "info", "value": "{{event.summary}}"}],
+											"url": "https://test.com"
+										}
+									],
+									"event_action": "trigger",
+									"extractions": [
+										{
+											"regex": null, "source": null, "target": "event.summary", "template": "{{event.summary}}, hostname: {{variables.hostname}}"
+										}
+									],
+									"priority": "PCMUB6F",
+									"route_to": "7589a1b9",
+									"severity": "warning",
+									"variables": [{"name": "hostname", "path": "event.source", "type": "regex", "value": ".*"}]
+								},
+								"conditions": [{"expression": "now in Mon,Tue,Wed,Thu,Fri 08:00:00 to 18:00:00 America/Los_Angeles"}],
+								"id": "4ad2c1be",
+								"label": "business hours"
+							}
+						]
+					},
+					{
+						"id": "7589a1b9",
+						"rules": [
+							{
+								"actions": {"annotate": "received more than 10 events over 5 minutes"},
+								"conditions": [{"expression": "trigger_count over 5 minute > 10"}],
+								"id": "fed68019",
+								"label": "too many events"
+							}
+						]
+					}
+				],
+				"type": "global",
+				"updated_at": "2023-01-26T16:03:55Z",
+				"updated_by": {"id": "P8B9WR8", "self": "https://api.pagerduty.com/users/P8B9WR8", "type": "user_reference"},
+				"version": "AbCdE.5"
+			}
+		}`))
+	})
+
+	resp, _, err := client.EventOrchestrationPaths.Update("E-ORC-1", PathTypeGlobal, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &EventOrchestrationPathPayload{
+		OrchestrationPath: &EventOrchestrationPath{
+			CatchAll: input.CatchAll,
+			CreatedAt: "2022-07-13T20:44:58Z",
+			CreatedBy: &EventOrchestrationPathReference{
+				ID:   "P8B9WR7",
+				Self: "https://api.pagerduty.com/users/P8B9WR7",
+				Type: "user_reference",
+			},
+			Parent: &EventOrchestrationPathReference{
+				ID:   "E-ORC-1",
+				Self: "https://api.pagerduty.com/event_orchestrations/E-ORC-1",
+				Type: "event_orchestration_reference",
+			},
+			Self: "https://api.pagerduty.com/event_orchestrations/E-ORC-1/global",
+			Sets: input.Sets,
+			Type: "global",
+			UpdatedAt: "2023-01-26T16:03:55Z",
+			UpdatedBy: &EventOrchestrationPathReference{
+				ID:   "P8B9WR8",
+				Self: "https://api.pagerduty.com/users/P8B9WR8",
+				Type: "user_reference",
+			},
+			Version: "AbCdE.5",
+		},
+	}
+
+	if !reflect.DeepEqual(resp, want) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp, want)
+	}
+}
+
+func TestEventOrchestrationPathRouterUpdate(t *testing.T) {
 	setup()
 	defer teardown()
 	input := &EventOrchestrationPath{
@@ -180,15 +483,9 @@ func TestEventOrchestrationPathRouterPathUpdate(t *testing.T) {
 
 	mux.HandleFunc(url, func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
-		v := new(EventOrchestrationPath)
-		v.Type = "router"
-		v.Parent = &EventOrchestrationPathReference{
-			ID:   "E-ORC-1",
-			Self: "https://api.pagerduty.com/event_orchestrations/E-ORC-1",
-			Type: "event_orchestration_reference",
-		}
+		v := new(EventOrchestrationPathPayload)
 		json.NewDecoder(r.Body).Decode(v)
-		if !reflect.DeepEqual(v, input) {
+		if !reflect.DeepEqual(v.OrchestrationPath, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 		w.Write([]byte(`{"orchestration_path": { "type": "router", "parent": { "id": "E-ORC-1", "self": "https://api.pagerduty.com/event_orchestrations/E-ORC-1", "type": "event_orchestration_reference" }, "sets": [ { "id": "start", "rules": [ { "actions": { "route_to": "P3ZQXDF" }, "conditions": [ { "expression": "event.summary matches part 'orca'" }, { "expression": "event.summary matches part 'humpback'" } ], "id": "E-ORC-RULE-1"}]}]}}`))
@@ -237,7 +534,7 @@ func TestEventOrchestrationPathRouterPathUpdate(t *testing.T) {
 	}
 }
 
-func TestEventOrchestrationPathUnroutedPathUpdate(t *testing.T) {
+func TestEventOrchestrationPathUnroutedUpdate(t *testing.T) {
 	setup()
 	defer teardown()
 	input := &EventOrchestrationPath{
@@ -253,15 +550,9 @@ func TestEventOrchestrationPathUnroutedPathUpdate(t *testing.T) {
 
 	mux.HandleFunc(url, func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
-		v := new(EventOrchestrationPath)
-		v.Type = "unrouted"
-		v.Parent = &EventOrchestrationPathReference{
-			ID:   "E-ORC-1",
-			Self: "https://api.pagerduty.com/event_orchestrations/E-ORC-1",
-			Type: "event_orchestration_reference",
-		}
+		v := new(EventOrchestrationPathPayload)
 		json.NewDecoder(r.Body).Decode(v)
-		if !reflect.DeepEqual(v, input) {
+		if !reflect.DeepEqual(v.OrchestrationPath, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 		w.Write([]byte(`{
@@ -331,37 +622,7 @@ func TestEventOrchestrationPathUnroutedPathUpdate(t *testing.T) {
 	}
 }
 
-func TestEventOrchestrationPathServiceActiveStatusUpdate(t *testing.T) {
-	setup()
-	defer teardown()
-	input := &EventOrchestrationPathServiceActiveStatus{Active: false}
-
-	var url = fmt.Sprintf("%s/services/P3ZQXDF/active", eventOrchestrationBaseUrl)
-
-	mux.HandleFunc(url, func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "PUT")
-		v := new(EventOrchestrationPathServiceActiveStatus)
-		v.Active = false
-		json.NewDecoder(r.Body).Decode(v)
-		if !reflect.DeepEqual(v, input) {
-			t.Errorf("Request body = %+v, want %+v", v, input)
-		}
-		w.Write([]byte(`{"active":false}`))
-	})
-
-	resp, _, err := client.EventOrchestrationPaths.UpdateServiceActiveStatus("P3ZQXDF", input.Active)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	want := &EventOrchestrationPathServiceActiveStatus{Active: false}
-
-	if !reflect.DeepEqual(resp, want) {
-		t.Errorf("returned \n\n%#v want \n\n%#v", resp, want)
-	}
-}
-
-func TestEventOrchestrationPathServicePathUpdate(t *testing.T) {
+func TestEventOrchestrationPathServiceUpdate(t *testing.T) {
 	setup()
 	defer teardown()
 	input := &EventOrchestrationPath{
@@ -377,15 +638,9 @@ func TestEventOrchestrationPathServicePathUpdate(t *testing.T) {
 
 	mux.HandleFunc(url, func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
-		v := new(EventOrchestrationPath)
-		v.Type = "service"
-		v.Parent = &EventOrchestrationPathReference{
-			ID:   "E-ORC-1",
-			Self: "https://api.pagerduty.com/event_orchestrations/E-ORC-1",
-			Type: "event_orchestration_reference",
-		}
+		v := new(EventOrchestrationPathPayload)
 		json.NewDecoder(r.Body).Decode(v)
-		if !reflect.DeepEqual(v, input) {
+		if !reflect.DeepEqual(v.OrchestrationPath, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
 		w.Write([]byte(`{
@@ -431,6 +686,36 @@ func TestEventOrchestrationPathServicePathUpdate(t *testing.T) {
 		},
 		Warnings: []*EventOrchestrationPathWarning{},
 	}
+
+	if !reflect.DeepEqual(resp, want) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp, want)
+	}
+}
+
+func TestEventOrchestrationPathServiceActiveStatusUpdate(t *testing.T) {
+	setup()
+	defer teardown()
+	input := &EventOrchestrationPathServiceActiveStatus{Active: false}
+
+	var url = fmt.Sprintf("%s/services/P3ZQXDF/active", eventOrchestrationBaseUrl)
+
+	mux.HandleFunc(url, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		v := new(EventOrchestrationPathServiceActiveStatus)
+		v.Active = false
+		json.NewDecoder(r.Body).Decode(v)
+		if !reflect.DeepEqual(v, input) {
+			t.Errorf("Request body = %+v, want %+v", v, input)
+		}
+		w.Write([]byte(`{"active":false}`))
+	})
+
+	resp, _, err := client.EventOrchestrationPaths.UpdateServiceActiveStatus("P3ZQXDF", input.Active)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &EventOrchestrationPathServiceActiveStatus{Active: false}
 
 	if !reflect.DeepEqual(resp, want) {
 		t.Errorf("returned \n\n%#v want \n\n%#v", resp, want)

--- a/pagerduty/event_orchestration_path_test.go
+++ b/pagerduty/event_orchestration_path_test.go
@@ -1,6 +1,7 @@
 package pagerduty
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -48,7 +49,7 @@ func TestEventOrchestrationPathGlobalGet(t *testing.T) {
 				"version": "Abcd.1234"
 			}
 		}`))
-	})	
+	})
 
 	resp, _, err := client.EventOrchestrationPaths.Get("E-ORC-1", PathTypeGlobal)
 
@@ -74,11 +75,11 @@ func TestEventOrchestrationPathGlobalGet(t *testing.T) {
 		Self: "https://api.pagerduty.com/event_orchestrations/E-ORC-1/global",
 		Sets: []*EventOrchestrationPathSet{
 			{
-				ID: "start",
+				ID:    "start",
 				Rules: []*EventOrchestrationPathRule{},
 			},
 		},
-		Type: "global",
+		Type:      "global",
 		UpdatedAt: "2022-12-15T13:57:08Z",
 		UpdatedBy: &EventOrchestrationPathReference{
 			ID:   "P8B9WR8",
@@ -234,7 +235,7 @@ func TestEventOrchestrationPathGetServiceActiveStatus(t *testing.T) {
 		}`))
 	})
 
-	resp, _, err := client.EventOrchestrationPaths.GetServiceActiveStatus("POOPBUG")
+	resp, _, err := client.EventOrchestrationPaths.GetServiceActiveStatusContext(context.Background(), "POOPBUG")
 
 	if err != nil {
 		t.Fatal(err)
@@ -271,7 +272,7 @@ func TestEventOrchestrationPathGlobalUpdate(t *testing.T) {
 								Expression: "event.summary matches part '[TEST]'",
 							},
 						},
-						ID: "240790f7",
+						ID:    "240790f7",
 						Label: "drop test events",
 					},
 					{
@@ -281,22 +282,22 @@ func TestEventOrchestrationPathGlobalUpdate(t *testing.T) {
 									AutoSend: true,
 									Headers: []*EventOrchestrationPathAutomationActionObject{
 										{
-											Key: "x-header-1",
+											Key:   "x-header-1",
 											Value: "h-one",
 										},
 										{
-											Key: "x-header-2",
+											Key:   "x-header-2",
 											Value: "h-two",
 										},
 									},
 									Name: "test webhook",
 									Parameters: []*EventOrchestrationPathAutomationActionObject{
 										{
-											Key: "hostname",
+											Key:   "hostname",
 											Value: "{{variables.hostname}}",
 										},
 										{
-											Key: "info",
+											Key:   "info",
 											Value: "{{event.summary}}",
 										},
 									},
@@ -306,18 +307,18 @@ func TestEventOrchestrationPathGlobalUpdate(t *testing.T) {
 							EventAction: "trigger",
 							Extractions: []*EventOrchestrationPathActionExtractions{
 								{
-									Target: "event.summary",
+									Target:   "event.summary",
 									Template: "{{event.summary}}, hostname: {{variables.hostname}}",
 								},
 							},
 							Priority: "PCMUB6F",
-							RouteTo: "7589a1b9",
+							RouteTo:  "7589a1b9",
 							Severity: "warning",
 							Variables: []*EventOrchestrationPathActionVariables{
 								{
-									Name: "hostname",
-									Path: "event.source",
-									Type: "regex",
+									Name:  "hostname",
+									Path:  "event.source",
+									Type:  "regex",
 									Value: ".*",
 								},
 							},
@@ -327,7 +328,7 @@ func TestEventOrchestrationPathGlobalUpdate(t *testing.T) {
 								Expression: "now in Mon,Tue,Wed,Thu,Fri 08:00:00 to 18:00:00 America/Los_Angeles",
 							},
 						},
-						ID: "4ad2c1be",
+						ID:    "4ad2c1be",
 						Label: "business hours",
 					},
 				},
@@ -344,7 +345,7 @@ func TestEventOrchestrationPathGlobalUpdate(t *testing.T) {
 								Expression: "trigger_count over 5 minute > 10",
 							},
 						},
-						ID: "fed68019",
+						ID:    "fed68019",
 						Label: "too many events",
 					},
 				},
@@ -437,7 +438,7 @@ func TestEventOrchestrationPathGlobalUpdate(t *testing.T) {
 
 	want := &EventOrchestrationPathPayload{
 		OrchestrationPath: &EventOrchestrationPath{
-			CatchAll: input.CatchAll,
+			CatchAll:  input.CatchAll,
 			CreatedAt: "2022-07-13T20:44:58Z",
 			CreatedBy: &EventOrchestrationPathReference{
 				ID:   "P8B9WR7",
@@ -449,9 +450,9 @@ func TestEventOrchestrationPathGlobalUpdate(t *testing.T) {
 				Self: "https://api.pagerduty.com/event_orchestrations/E-ORC-1",
 				Type: "event_orchestration_reference",
 			},
-			Self: "https://api.pagerduty.com/event_orchestrations/E-ORC-1/global",
-			Sets: input.Sets,
-			Type: "global",
+			Self:      "https://api.pagerduty.com/event_orchestrations/E-ORC-1/global",
+			Sets:      input.Sets,
+			Type:      "global",
 			UpdatedAt: "2023-01-26T16:03:55Z",
 			UpdatedBy: &EventOrchestrationPathReference{
 				ID:   "P8B9WR8",
@@ -601,17 +602,17 @@ func TestEventOrchestrationPathUnroutedUpdate(t *testing.T) {
 		},
 		Warnings: []*EventOrchestrationPathWarning{
 			&EventOrchestrationPathWarning{
-				Feature: "variables",
+				Feature:     "variables",
 				FeatureType: "actions",
-				Message: "Message 1",
-				RuleId: "abcd001",
+				Message:     "Message 1",
+				RuleId:      "abcd001",
 				WarningType: "forbidden_feature",
 			},
 			&EventOrchestrationPathWarning{
-				Feature: "extractions",
+				Feature:     "extractions",
 				FeatureType: "actions",
-				Message: "Message 2",
-				RuleId: "abcd002",
+				Message:     "Message 2",
+				RuleId:      "abcd002",
 				WarningType: "forbidden_feature",
 			},
 		},
@@ -710,7 +711,7 @@ func TestEventOrchestrationPathServiceActiveStatusUpdate(t *testing.T) {
 		w.Write([]byte(`{"active":false}`))
 	})
 
-	resp, _, err := client.EventOrchestrationPaths.UpdateServiceActiveStatus("P3ZQXDF", input.Active)
+	resp, _, err := client.EventOrchestrationPaths.UpdateServiceActiveStatusContext(context.Background(), "P3ZQXDF", input.Active)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pagerduty/pagerduty.go
+++ b/pagerduty/pagerduty.go
@@ -44,6 +44,7 @@ type Client struct {
 	Rulesets                     *RulesetService
 	EventOrchestrations          *EventOrchestrationService
 	EventOrchestrationPaths      *EventOrchestrationPathService
+	EventOrchestrationIntegrations *EventOrchestrationIntegrationService
 	Schedules                    *ScheduleService
 	Services                     *ServicesService
 	Teams                        *TeamService
@@ -113,6 +114,7 @@ func NewClient(config *Config) (*Client, error) {
 	c.MaintenanceWindows = &MaintenanceWindowService{c}
 	c.Rulesets = &RulesetService{c}
 	c.EventOrchestrations = &EventOrchestrationService{c}
+	c.EventOrchestrationIntegrations = &EventOrchestrationIntegrationService{c}
 	c.EventOrchestrationPaths = &EventOrchestrationPathService{c}
 	c.Schedules = &ScheduleService{c}
 	c.Services = &ServicesService{c}

--- a/pagerduty/pagerduty.go
+++ b/pagerduty/pagerduty.go
@@ -33,43 +33,43 @@ type Config struct {
 
 // Client manages the communication with the PagerDuty API
 type Client struct {
-	baseURL                      *url.URL
-	client                       *http.Client
-	Config                       *Config
-	Abilities                    *AbilityService
-	Addons                       *AddonService
-	EscalationPolicies           *EscalationPolicyService
-	Extensions                   *ExtensionService
-	MaintenanceWindows           *MaintenanceWindowService
-	Rulesets                     *RulesetService
-	EventOrchestrations          *EventOrchestrationService
-	EventOrchestrationPaths      *EventOrchestrationPathService
+	baseURL                        *url.URL
+	client                         *http.Client
+	Config                         *Config
+	Abilities                      *AbilityService
+	Addons                         *AddonService
+	EscalationPolicies             *EscalationPolicyService
+	Extensions                     *ExtensionService
+	MaintenanceWindows             *MaintenanceWindowService
+	Rulesets                       *RulesetService
+	EventOrchestrations            *EventOrchestrationService
+	EventOrchestrationPaths        *EventOrchestrationPathService
 	EventOrchestrationIntegrations *EventOrchestrationIntegrationService
-	Schedules                    *ScheduleService
-	Services                     *ServicesService
-	Teams                        *TeamService
-	ExtensionSchemas             *ExtensionSchemaService
-	Users                        *UserService
-	Licenses                     *LicenseService
-	Vendors                      *VendorService
-	EventRules                   *EventRuleService
-	BusinessServices             *BusinessServiceService
-	ServiceDependencies          *ServiceDependencyService
-	Priorities                   *PriorityService
-	ResponsePlays                *ResponsePlayService
-	SlackConnections             *SlackConnectionService
-	Tags                         *TagService
-	WebhookSubscriptions         *WebhookSubscriptionService
-	BusinessServiceSubscribers   *BusinessServiceSubscriberService
-	OnCall                       *OnCallService
-	AutomationActionsRunner      *AutomationActionsRunnerService
-	AutomationActionsAction      *AutomationActionsActionService
-	Incidents                    *IncidentService
-	IncidentWorkflows            *IncidentWorkflowService
-	IncidentWorkflowTriggers     *IncidentWorkflowTriggerService
-	CustomFields                 *CustomFieldService
-	CustomFieldSchemas           *CustomFieldSchemaService
-	CustomFieldSchemaAssignments *CustomFieldSchemaAssignmentService
+	Schedules                      *ScheduleService
+	Services                       *ServicesService
+	Teams                          *TeamService
+	ExtensionSchemas               *ExtensionSchemaService
+	Users                          *UserService
+	Licenses                       *LicenseService
+	Vendors                        *VendorService
+	EventRules                     *EventRuleService
+	BusinessServices               *BusinessServiceService
+	ServiceDependencies            *ServiceDependencyService
+	Priorities                     *PriorityService
+	ResponsePlays                  *ResponsePlayService
+	SlackConnections               *SlackConnectionService
+	Tags                           *TagService
+	WebhookSubscriptions           *WebhookSubscriptionService
+	BusinessServiceSubscribers     *BusinessServiceSubscriberService
+	OnCall                         *OnCallService
+	AutomationActionsRunner        *AutomationActionsRunnerService
+	AutomationActionsAction        *AutomationActionsActionService
+	Incidents                      *IncidentService
+	IncidentWorkflows              *IncidentWorkflowService
+	IncidentWorkflowTriggers       *IncidentWorkflowTriggerService
+	CustomFields                   *CustomFieldService
+	CustomFieldSchemas             *CustomFieldSchemaService
+	CustomFieldSchemaAssignments   *CustomFieldSchemaAssignmentService
 }
 
 // Response is a wrapper around http.Response


### PR DESCRIPTION
## Changes
### Orchestration Warnings (ORCA-3828)
Modifies the signature of the Event Orchestration Path Update method to return the entire response instead of just the `orchestration_path` property. The Public API endpoints to update a Router / Unrouted / Service Orchestration have been extended with a `warnings` property that now returns a list of forbidden features that will be skipped during orchestration evaluation. We want to use these warnings in the Provider and display them to the user on `terraform apply`.

These changes have been reviewed in https://github.com/heimweh/go-pagerduty/pull/105

### Global Orchestrations (ORCA-3893 & ORCA-3895)
Adds support for Global Orchestrations to the existing CRUD methods.

### Orchestration Integrations (ORCA-3946 & ORCA-3947)
Adds CRUD methods and models for Event Orchestration Integrations

## ⚠️ Before Merging

- [x] Update the Global orchestration URL in the comment after the Public API docs are released
- [ ] These changes break current Provider code and **MUST** be merged in right before https://github.com/PagerDuty/terraform-provider-pagerduty/pull/618