### PR TITLE
remove `X-EARLY-ACCESS` header on `/incident-worflows` calls

### DIFF
--- a/pagerduty/incident_workflow.go
+++ b/pagerduty/incident_workflow.go
@@ -55,12 +55,6 @@ type IncidentWorkflowPayload struct {
 	IncidentWorkflow *IncidentWorkflow `json:"incident_workflow,omitempty"`
 }
 
-var incidentWorkflowsEarlyAccessHeader = RequestOptions{
-	Type:  "header",
-	Label: "X-EARLY-ACCESS",
-	Value: "incident-workflows-early-access",
-}
-
 // ListIncidentWorkflowOptions represents options when retrieving a list of incident workflows.
 type ListIncidentWorkflowOptions struct {
 	Offset   int      `url:"offset,omitempty"`
@@ -102,7 +96,7 @@ func (s *IncidentWorkflowService) ListContext(ctx context.Context, o *ListIncide
 	}
 
 	if o.Limit != 0 {
-		resp, err := s.client.newRequestDoOptionsContext(ctx, "GET", u, o, nil, &v, incidentWorkflowsEarlyAccessHeader)
+		resp, err := s.client.newRequestDoContext(ctx, "GET", u, o, nil, &v)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -132,7 +126,7 @@ func (s *IncidentWorkflowService) ListContext(ctx context.Context, o *ListIncide
 		}
 		err := s.client.newRequestPagedGetQueryDoContext(ctx, u, responseHandler, &listIncidentWorkflowOptionsGen{
 			options: o,
-		}, incidentWorkflowsEarlyAccessHeader)
+		})
 		if err != nil {
 			return nil, nil, err
 		}
@@ -152,7 +146,7 @@ func (s *IncidentWorkflowService) GetContext(ctx context.Context, id string) (*I
 	u := fmt.Sprintf("/incident_workflows/%s", id)
 	v := new(IncidentWorkflowPayload)
 
-	resp, err := s.client.newRequestDoOptionsContext(ctx, "GET", u, nil, nil, v, incidentWorkflowsEarlyAccessHeader)
+	resp, err := s.client.newRequestDoContext(ctx, "GET", u, nil, nil, v)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -170,7 +164,7 @@ func (s *IncidentWorkflowService) CreateContext(ctx context.Context, iw *Inciden
 	u := "/incident_workflows"
 	v := new(IncidentWorkflowPayload)
 
-	resp, err := s.client.newRequestDoOptionsContext(ctx, "POST", u, nil, &IncidentWorkflowPayload{IncidentWorkflow: iw}, &v, incidentWorkflowsEarlyAccessHeader)
+	resp, err := s.client.newRequestDoContext(ctx, "POST", u, nil, &IncidentWorkflowPayload{IncidentWorkflow: iw}, &v)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -186,7 +180,7 @@ func (s *IncidentWorkflowService) Delete(id string) (*Response, error) {
 // DeleteContext removes an existing incident workflow.
 func (s *IncidentWorkflowService) DeleteContext(ctx context.Context, id string) (*Response, error) {
 	u := fmt.Sprintf("/incident_workflows/%s", id)
-	return s.client.newRequestDoOptionsContext(ctx, "DELETE", u, nil, nil, nil, incidentWorkflowsEarlyAccessHeader)
+	return s.client.newRequestDoContext(ctx, "DELETE", u, nil, nil, nil)
 }
 
 // Update updates an existing incident workflow.
@@ -199,7 +193,7 @@ func (s *IncidentWorkflowService) UpdateContext(ctx context.Context, id string, 
 	u := fmt.Sprintf("/incident_workflows/%s", id)
 	v := new(IncidentWorkflowPayload)
 
-	resp, err := s.client.newRequestDoOptionsContext(ctx, "PUT", u, nil, &IncidentWorkflowPayload{IncidentWorkflow: iw}, &v, incidentWorkflowsEarlyAccessHeader)
+	resp, err := s.client.newRequestDoContext(ctx, "PUT", u, nil, &IncidentWorkflowPayload{IncidentWorkflow: iw}, &v)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pagerduty/incident_workflow_test.go
+++ b/pagerduty/incident_workflow_test.go
@@ -13,7 +13,6 @@ func TestIncidentWorkflowList(t *testing.T) {
 	mux.HandleFunc("/incident_workflows", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testQueryMaxCount(t, r, 1)
-		testHeader(t, r, "x-early-access", "incident-workflows-early-access")
 		offset := r.URL.Query().Get("offset")
 
 		switch offset {
@@ -58,7 +57,6 @@ func TestIncidentWorkflowList_SecondPage(t *testing.T) {
 
 	mux.HandleFunc("/incident_workflows", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "x-early-access", "incident-workflows-early-access")
 		testQueryCount(t, r, 1)
 		offset := r.URL.Query().Get("offset")
 
@@ -99,7 +97,6 @@ func TestIncidentWorkflowList_Limit(t *testing.T) {
 
 	mux.HandleFunc("/incident_workflows", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "x-early-access", "incident-workflows-early-access")
 		testQueryCount(t, r, 1)
 		testQueryValue(t, r, "limit", "42")
 
@@ -135,7 +132,6 @@ func TestIncidentWorkflowList_WithOptions(t *testing.T) {
 
 	mux.HandleFunc("/incident_workflows", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "x-early-access", "incident-workflows-early-access")
 
 		testQueryMinCount(t, r, 1)
 		testQueryMaxCount(t, r, 2)
@@ -186,7 +182,6 @@ func TestIncidentWorkflowGet(t *testing.T) {
 
 	mux.HandleFunc("/incident_workflows/IW1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "x-early-access", "incident-workflows-early-access")
 		testBody(t, r, "")
 
 		w.Write([]byte(`
@@ -326,7 +321,6 @@ func TestIncidentWorkflowCreate(t *testing.T) {
 
 	mux.HandleFunc("/incident_workflows", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		testHeader(t, r, "x-early-access", "incident-workflows-early-access")
 		testBody(t, r, `{"incident_workflow":{"name":"Example Workflow","description":"This workflow serves as an example","steps":[{"name":"Example Step","description":"An example workflow step","action_configuration":{"action_id":"example/action/v1","inputs":[{"name":"Example input","value":"{{ example-value }}"}]}},{"name":"Subsequent Step","description":"A subsequent step in this workflow","action_configuration":{"action_id":"example/action/v1","inputs":[{"name":"Example input","value":"{{ example-value }}"}]}}]}}`)
 
 		w.Write([]byte(`
@@ -488,7 +482,6 @@ func TestIncidentWorkflowDelete(t *testing.T) {
 
 	mux.HandleFunc("/incident_workflows/IW1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
-		testHeader(t, r, "x-early-access", "incident-workflows-early-access")
 		w.WriteHeader(200)
 	})
 
@@ -508,7 +501,6 @@ func TestIncidentWorkflowUpdate(t *testing.T) {
 
 	mux.HandleFunc("/incident_workflows/IW1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
-		testHeader(t, r, "x-early-access", "incident-workflows-early-access")
 		testBody(t, r, `{"incident_workflow":{"description":"Updated description","steps":[{"id":"32OIHWEJ"},{"id":"D3IT0D3","name":"Subsequent Step Updated Name"}]}}`)
 
 		w.Write([]byte(`

--- a/pagerduty/incident_workflow_trigger.go
+++ b/pagerduty/incident_workflow_trigger.go
@@ -75,7 +75,7 @@ func (s *IncidentWorkflowTriggerService) ListContext(ctx context.Context, o *Lis
 	}
 
 	if o.Limit != 0 {
-		resp, err := s.client.newRequestDoOptionsContext(ctx, "GET", u, o, nil, &v, incidentWorkflowsEarlyAccessHeader)
+		resp, err := s.client.newRequestDoContext(ctx, "GET", u, o, nil, &v)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -104,7 +104,7 @@ func (s *IncidentWorkflowTriggerService) ListContext(ctx context.Context, o *Lis
 		}
 		err := s.client.newRequestCursorPagedGetQueryDoContext(ctx, u, responseHandler, &listIncidentWorkflowTriggerOptionsGen{
 			options: o,
-		}, incidentWorkflowsEarlyAccessHeader)
+		})
 		if err != nil {
 			return nil, nil, err
 		}
@@ -124,7 +124,7 @@ func (s *IncidentWorkflowTriggerService) GetContext(ctx context.Context, id stri
 	u := fmt.Sprintf("/incident_workflows/triggers/%s", id)
 	v := new(IncidentWorkflowTriggerPayload)
 
-	resp, err := s.client.newRequestDoOptionsContext(ctx, "GET", u, nil, nil, v, incidentWorkflowsEarlyAccessHeader)
+	resp, err := s.client.newRequestDoContext(ctx, "GET", u, nil, nil, v)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -142,7 +142,7 @@ func (s *IncidentWorkflowTriggerService) CreateContext(ctx context.Context, t *I
 	u := "/incident_workflows/triggers"
 	v := new(IncidentWorkflowTriggerPayload)
 
-	resp, err := s.client.newRequestDoOptionsContext(ctx, "POST", u, nil, &t, &v, incidentWorkflowsEarlyAccessHeader)
+	resp, err := s.client.newRequestDoContext(ctx, "POST", u, nil, &t, &v)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -158,7 +158,7 @@ func (s *IncidentWorkflowTriggerService) Delete(id string) (*Response, error) {
 // DeleteContext removes an existing incident workflow trigger.
 func (s *IncidentWorkflowTriggerService) DeleteContext(ctx context.Context, id string) (*Response, error) {
 	u := fmt.Sprintf("/incident_workflows/triggers/%s", id)
-	return s.client.newRequestDoOptionsContext(ctx, "DELETE", u, nil, nil, nil, incidentWorkflowsEarlyAccessHeader)
+	return s.client.newRequestDoContext(ctx, "DELETE", u, nil, nil, nil)
 }
 
 // Update updates an existing incident workflow trigger.
@@ -171,7 +171,7 @@ func (s *IncidentWorkflowTriggerService) UpdateContext(ctx context.Context, id s
 	u := fmt.Sprintf("/incident_workflows/triggers/%s", id)
 	v := new(IncidentWorkflowTriggerPayload)
 
-	resp, err := s.client.newRequestDoOptionsContext(ctx, "PUT", u, nil, &t, &v, incidentWorkflowsEarlyAccessHeader)
+	resp, err := s.client.newRequestDoContext(ctx, "PUT", u, nil, &t, &v)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pagerduty/incident_workflow_trigger_test.go
+++ b/pagerduty/incident_workflow_trigger_test.go
@@ -12,7 +12,6 @@ func TestIncidentWorkflowTriggerList(t *testing.T) {
 
 	mux.HandleFunc("/incident_workflows/triggers", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "x-early-access", "incident-workflows-early-access")
 		testQueryMaxCount(t, r, 1)
 		pageToken := r.URL.Query().Get("page_token")
 
@@ -60,7 +59,6 @@ func TestIncidentWorkflowTriggerList_SecondPage(t *testing.T) {
 
 	mux.HandleFunc("/incident_workflows/triggers", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "x-early-access", "incident-workflows-early-access")
 		testQueryCount(t, r, 1)
 		pageToken := r.URL.Query().Get("page_token")
 
@@ -98,7 +96,6 @@ func TestIncidentWorkflowTriggerList_Limit(t *testing.T) {
 
 	mux.HandleFunc("/incident_workflows/triggers", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "x-early-access", "incident-workflows-early-access")
 		testQueryCount(t, r, 1)
 		testQueryValue(t, r, "limit", "42")
 
@@ -131,7 +128,6 @@ func TestIncidentWorkflowTriggerList_WithOptions(t *testing.T) {
 
 	mux.HandleFunc("/incident_workflows/triggers", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "x-early-access", "incident-workflows-early-access")
 
 		testQueryMinCount(t, r, 1)
 		testQueryMaxCount(t, r, 2)
@@ -178,7 +174,6 @@ func TestIncidentWorkflowTriggerGet(t *testing.T) {
 
 	mux.HandleFunc("/incident_workflows/triggers/IWT1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "x-early-access", "incident-workflows-early-access")
 		testBody(t, r, "")
 
 		w.Write([]byte(`
@@ -263,7 +258,6 @@ func TestIncidentWorkflowTriggerCreate(t *testing.T) {
 
 	mux.HandleFunc("/incident_workflows/triggers", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		testHeader(t, r, "x-early-access", "incident-workflows-early-access")
 		testBody(t, r, `{"trigger_type":"manual","workflow":{"id":"TO38234"},"services":[{"id":"PIJ90N7"}],"condition":"incident.priority matches 'P1'"}`)
 
 		w.Write([]byte(`
@@ -358,7 +352,6 @@ func TestIncidentWorkflowTriggerDelete(t *testing.T) {
 
 	mux.HandleFunc("/incident_workflows/triggers/IWT1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
-		testHeader(t, r, "x-early-access", "incident-workflows-early-access")
 		w.WriteHeader(200)
 	})
 
@@ -378,7 +371,6 @@ func TestIncidentWorkflowTriggerUpdate(t *testing.T) {
 
 	mux.HandleFunc("/incident_workflows/triggers/IW1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
-		testHeader(t, r, "x-early-access", "incident-workflows-early-access")
 		testBody(t, r, `{"services":[{"id":"PIJ90N7"}],"condition":"incident.priority matches 'P1'"}`)
 
 		w.Write([]byte(`


### PR DESCRIPTION
Header `X-EARLY-ACCESS` is no longer for making calls to `/incident-workflows`, so with this update We are proceeding to remove it from mentioned context.