### PR TITLE
RDC-1062 Add node filtering for automation action resources

### DIFF
--- a/pagerduty/automation_actions_action.go
+++ b/pagerduty/automation_actions_action.go
@@ -26,6 +26,7 @@ type AutomationActionsAction struct {
 type AutomationActionsActionDataReference struct {
 	ProcessAutomationJobId        *string `json:"process_automation_job_id,omitempty"`
 	ProcessAutomationJobArguments *string `json:"process_automation_job_arguments,omitempty"`
+	ProcessAutomationNodeFilter   *string `json:"process_automation_node_filter,omitempty"`
 	Script                        *string `json:"script,omitempty"`
 	InvocationCommand             *string `json:"invocation_command,omitempty"`
 }

--- a/pagerduty/automation_actions_action_test.go
+++ b/pagerduty/automation_actions_action_test.go
@@ -91,10 +91,12 @@ func TestAutomationActionsActionTypeProcessAutomationCreate(t *testing.T) {
 	description := "Description of Action created by TF"
 	runner_id := "01DF4O9T1MDPYOUT7SUX9EXZ4R"
 	adf_arg := "-arg 123"
+	adf_node_filter := "tags: production"
 	job_id := "1519578e-a22a-4340-b58f-08194691e10b"
 	adf := AutomationActionsActionDataReference{
 		ProcessAutomationJobId:        &job_id,
 		ProcessAutomationJobArguments: &adf_arg,
+		ProcessAutomationNodeFilter: &adf_node_filter,
 	}
 	input := &AutomationActionsAction{
 		Name:                "Action created by TF",
@@ -111,7 +113,7 @@ func TestAutomationActionsActionTypeProcessAutomationCreate(t *testing.T) {
 		if !reflect.DeepEqual(v.Action, input) {
 			t.Errorf("Request body = %+v, want %+v", v.Action, input)
 		}
-		w.Write([]byte(`{"action":{"action_data_reference":{"process_automation_job_id":"1519578e-a22a-4340-b58f-08194691e10b","process_automation_job_arguments":"-arg 123"},"action_type":"process_automation","creation_time":"2022-12-12T18:51:42.048162Z","description":"Description of Action created by TF","id":"01DF4OBNYKW84FS9CCYVYS1MOS","last_run":"2022-12-12T18:52:11.937747Z","last_run_by":{"id":"PINL781","type":"user_reference"},"modify_time":"2022-12-12T18:51:42.048162Z","name":"Action created by TF","privileges":{"permissions":["read"]},"runner":"01DF4O9T1MDPYOUT7SUX9EXZ4R","runner_type":"runbook","services":[{"id":"PQWQ0U6","type":"service_reference"}],"teams":[{"id":"PZ31N6S","type":"team_reference"}],"type":"action"}}`))
+		w.Write([]byte(`{"action":{"action_data_reference":{"process_automation_job_id":"1519578e-a22a-4340-b58f-08194691e10b","process_automation_job_arguments":"-arg 123", "process_automation_node_filter":"tags: production"},"action_type":"process_automation","creation_time":"2022-12-12T18:51:42.048162Z","description":"Description of Action created by TF","id":"01DF4OBNYKW84FS9CCYVYS1MOS","last_run":"2022-12-12T18:52:11.937747Z","last_run_by":{"id":"PINL781","type":"user_reference"},"modify_time":"2022-12-12T18:51:42.048162Z","name":"Action created by TF","privileges":{"permissions":["read"]},"runner":"01DF4O9T1MDPYOUT7SUX9EXZ4R","runner_type":"runbook","services":[{"id":"PQWQ0U6","type":"service_reference"}],"teams":[{"id":"PZ31N6S","type":"team_reference"}],"type":"action"}}`))
 	})
 
 	resp, _, err := client.AutomationActionsAction.Create(input)
@@ -164,10 +166,12 @@ func TestAutomationActionsActionUpdate(t *testing.T) {
 	description := "Description of Action created by TF"
 	runner_id := "01DF4O9T1MDPYOUT7SUX9EXZ4R"
 	adf_arg := "-arg 123"
+	adf_node_filter := "tags: production"
 	job_id := "1519578e-a22a-4340-b58f-08194691e10b"
 	adf := AutomationActionsActionDataReference{
 		ProcessAutomationJobId:        &job_id,
 		ProcessAutomationJobArguments: &adf_arg,
+		ProcessAutomationNodeFilter:   &adf_node_filter,
 	}
 	input := &AutomationActionsAction{
 		Name:                "Action created by TF",
@@ -187,7 +191,7 @@ func TestAutomationActionsActionUpdate(t *testing.T) {
 		if !reflect.DeepEqual(v.Action, input) {
 			t.Errorf("Request body = %+v, want %+v", v.Action, input)
 		}
-		w.Write([]byte(`{"action":{"action_data_reference":{"process_automation_job_id":"1519578e-a22a-4340-b58f-08194691e10b","process_automation_job_arguments":"-arg 123"},"action_type":"process_automation","creation_time":"2022-12-12T18:51:42.048162Z","description":"Description of Action created by TF","id":"01DF4OBNYKW84FS9CCYVYS1MOS","last_run":"2022-12-12T18:52:11.937747Z","last_run_by":{"id":"PINL781","type":"user_reference"},"modify_time":"2022-12-12T18:51:42.048162Z","name":"Action created by TF","privileges":{"permissions":["read"]},"runner":"01DF4O9T1MDPYOUT7SUX9EXZ4R","runner_type":"runbook","services":[{"id":"PQWQ0U6","type":"service_reference"}],"teams":[{"id":"PZ31N6S","type":"team_reference"}],"type":"action"}}`))
+		w.Write([]byte(`{"action":{"action_data_reference":{"process_automation_job_id":"1519578e-a22a-4340-b58f-08194691e10b","process_automation_job_arguments":"-arg 123", "process_automation_node_filter":"tags: production"},"action_type":"process_automation","creation_time":"2022-12-12T18:51:42.048162Z","description":"Description of Action created by TF","id":"01DF4OBNYKW84FS9CCYVYS1MOS","last_run":"2022-12-12T18:52:11.937747Z","last_run_by":{"id":"PINL781","type":"user_reference"},"modify_time":"2022-12-12T18:51:42.048162Z","name":"Action created by TF","privileges":{"permissions":["read"]},"runner":"01DF4O9T1MDPYOUT7SUX9EXZ4R","runner_type":"runbook","services":[{"id":"PQWQ0U6","type":"service_reference"}],"teams":[{"id":"PZ31N6S","type":"team_reference"}],"type":"action"}}`))
 	})
 
 	resp, _, err := client.AutomationActionsAction.Update(id, input)


### PR DESCRIPTION
Adds new field `process_automation_node_filter` to the `action_data_reference` Automation Action's schema.