### PR TITLE
adds support for License Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ go get github.com/heimweh/go-pagerduty/pagerduty
 ```
 
 ## Example usage
-1. Create the following in a file at some path like the project root `go-pagerduty/main.go`
+1. Add something like the following to a go project:
+
 ```go
 package main
 
@@ -44,11 +45,9 @@ func main() {
 }
 ```
 
-2. This file may be used to test any recent local changes because
-   `github.com/heimweh/go-pagerduty` is the referenced module in `go.mod`
-3. So, in the project root run:
+2. run:
 ```bash
-$ TF_PAGERDUTY_CACHE=memory PAGERDUTY_TOKEN=<SECRET> go run <PATH/TO>/main.go
+$ PAGERDUTY_TOKEN=<SECRET> go run <PATH/TO/PROJECT/WITH/ABOVE/CODE>/main.go
 ```
 
 ## Caching support

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ go get github.com/heimweh/go-pagerduty/pagerduty
 ```
 
 ## Example usage
+1. Create the following in a file at some path like the project root `go-pagerduty/main.go`
 ```go
 package main
 
@@ -41,6 +42,13 @@ func main() {
 	// All calls returns the raw *http.Response for further inspection.
 	fmt.Println(raw.Response.StatusCode)
 }
+```
+
+2. This file may be used to test any recent local changes because
+   `github.com/heimweh/go-pagerduty` is the referenced module in `go.mod`
+3. So, in the project root run:
+```bash
+$ TF_PAGERDUTY_CACHE=memory PAGERDUTY_TOKEN=<SECRET> go run <PATH/TO>/main.go
 ```
 
 ## Caching support

--- a/pagerduty/license.go
+++ b/pagerduty/license.go
@@ -1,0 +1,101 @@
+package pagerduty
+
+import (
+	"log"
+)
+
+// LicenseService handles the communication with license
+// related methods of the PagerDuty API.
+type LicenseService service
+
+// License represents a License
+type License struct {
+	ID          string   `json:"id,omitempty"`
+	Type        string   `json:"type,omitempty"`
+	Name        string   `json:"name,omitempty"`
+	Summary     string   `json:"summary,omitempty"`
+	Description string   `json:"description,omitempty"`
+	RoleGroup   string   `json:"role_group,omitempty"`
+	ValidRoles  []string `json:"valid_roles,omitempty"`
+
+	// The following values may be set to null or unset, so their types are
+	// pointers to better translate these conditions rather than defaulting
+	// to 0 or ""
+	HTMLURL              *string `json:"html_url,omitempty"`
+	Self                 *string `json:"self,omitempty"`
+	AllocationsAvailable *int    `json:"allocations_available,omitempty"`
+	CurrentValue         *int    `json:"current_value,omitempty"`
+}
+
+// LicenseAllocation represents a LicenseAllocation
+type LicenseAllocation struct {
+	License     *License       `json:"license,omitempty"`
+	User        *UserReference `json:"user,omitempty"`
+	AllocatedAt string         `json:"allocated_at,omitempty"`
+}
+
+// ListLicenseAllocationsOptions represents options when listing license_allocations.
+type ListLicenseAllocationsOptions struct {
+	Limit  int  `url:"limit,omitempty"`
+	More   bool `url:"more,omitempty"`
+	Offset int  `url:"offset,omitempty"`
+	Total  int  `url:"total,omitempty"`
+}
+
+// ListLicenseAllocationsResponse represents a list response of license_allocations.
+type ListLicenseAllocationsResponse struct {
+	Limit              int                  `json:"limit,omitempty"`
+	More               bool                 `json:"more,omitempty"`
+	Offset             int                  `json:"offset,omitempty"`
+	Total              int                  `json:"total,omitempty"`
+	LicenseAllocations []*LicenseAllocation `json:"license_allocations,omitempty"`
+}
+
+// ListLicensesResponse represents a list response of licenses.
+type ListResponse struct {
+	Licenses []*License `json:"licenses,omitempty"`
+}
+
+// List lists existing Licenses.
+func (s *LicenseService) List() ([]*License, *Response, error) {
+	u := "/licenses"
+	v := new(ListResponse)
+
+	resp, err := s.client.newRequestDo("GET", u, nil, nil, &v)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v.Licenses, resp, nil
+}
+
+// ListAllocations lists existing LicenseAllocations.
+func (s *LicenseService) ListAllocations(o *ListLicenseAllocationsOptions) (*ListLicenseAllocationsResponse, *Response, error) {
+	u := "/license_allocations"
+	v := new(ListLicenseAllocationsResponse)
+
+	resp, err := s.client.newRequestDo("GET", u, o, nil, &v)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v, resp, nil
+}
+
+// ListAllAllocations lists all existing LicenseAllocations for an Account.
+func (s *LicenseService) ListAllAllocations(o *ListLicenseAllocationsOptions) ([]*LicenseAllocation, error) {
+	o.More, o.Offset = true, 0
+	var licenseAllocations = make([]*LicenseAllocation, 0, o.Limit)
+
+	for o.More {
+		log.Printf("==== Getting license_allocations at offset %d", o.Offset)
+		v, _, err := s.ListAllocations(o)
+		if err != nil {
+			return licenseAllocations, err
+		}
+		licenseAllocations = append(licenseAllocations, v.LicenseAllocations...)
+		o.More = v.More
+		o.Offset = o.Offset + v.Limit
+	}
+	return licenseAllocations, nil
+}

--- a/pagerduty/license_test.go
+++ b/pagerduty/license_test.go
@@ -1,0 +1,100 @@
+package pagerduty
+
+import (
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestLicensesList(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/licenses", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		w.Write([]byte(`{"licenses": [{"id": "P1D3Z4B"}]}`))
+	})
+
+	resp, _, err := client.Licenses.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []*License{
+		{
+			ID: "P1D3Z4B",
+		},
+	}
+
+	if !reflect.DeepEqual(resp, want) {
+		t.Errorf("returned %#v; want %#v", resp, want)
+	}
+}
+
+func TestListAllocations(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/license_allocations", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		w.Write([]byte(`{"license_allocations": [
+			{
+				"user": {"id": "P1D3Z4B", "type": "user_reference"},
+				"license": {"id": "P1D3XYZ", "type": "license"},
+				"allocated_at": "2021-06-01T21:30:42Z"
+			}
+		]}`))
+	})
+
+	resp, _, err := client.Licenses.ListAllocations(&ListLicenseAllocationsOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &ListLicenseAllocationsResponse{
+		LicenseAllocations: []*LicenseAllocation{
+			{
+				License:     &License{ID: "P1D3XYZ", Type: "license"},
+				User:        &UserReference{ID: "P1D3Z4B", Type: "user_reference"},
+				AllocatedAt: "2021-06-01T21:30:42Z",
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(resp, want) {
+		t.Errorf("returned %#v; want %#v", resp, want)
+	}
+}
+
+func TestListAllAllocations(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/license_allocations", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		w.Write([]byte(`{"license_allocations": [
+			{
+				"user": {"id": "P1D3Z4B", "type": "user_reference"},
+				"license": {"id": "P1D3XYZ", "type": "license"},
+				"allocated_at": "2021-06-01T21:30:42Z"
+			}
+		]}`))
+	})
+
+	resp, err := client.Licenses.ListAllAllocations(&ListLicenseAllocationsOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []*LicenseAllocation{
+		{
+			License:     &License{ID: "P1D3XYZ", Type: "license"},
+			User:        &UserReference{ID: "P1D3Z4B", Type: "user_reference"},
+			AllocatedAt: "2021-06-01T21:30:42Z",
+		},
+	}
+
+	if !reflect.DeepEqual(resp, want) {
+		t.Errorf("returned %#v; want %#v", resp, want)
+	}
+}

--- a/pagerduty/pagerduty.go
+++ b/pagerduty/pagerduty.go
@@ -49,6 +49,7 @@ type Client struct {
 	Teams                        *TeamService
 	ExtensionSchemas             *ExtensionSchemaService
 	Users                        *UserService
+	Licenses                     *LicenseService
 	Vendors                      *VendorService
 	EventRules                   *EventRuleService
 	BusinessServices             *BusinessServiceService
@@ -117,6 +118,7 @@ func NewClient(config *Config) (*Client, error) {
 	c.Services = &ServicesService{c}
 	c.Teams = &TeamService{c}
 	c.Users = &UserService{c}
+	c.Licenses = &LicenseService{c}
 	c.Vendors = &VendorService{c}
 	c.Extensions = &ExtensionService{c}
 	c.ExtensionSchemas = &ExtensionSchemaService{c}

--- a/pagerduty/references.go
+++ b/pagerduty/references.go
@@ -28,6 +28,9 @@ type ScheduleReference resourceReference
 // TeamReference represents a reference to a team.
 type TeamReference resourceReference
 
+// LicenseReference represents a reference to a team.
+type LicenseReference resourceReference
+
 // ContactMethodReference represents a reference to a contact method.
 type ContactMethodReference resourceReference
 


### PR DESCRIPTION
These changes are required to support license management in the Terraform Provider in this [PR](https://github.com/PagerDuty/terraform-provider-pagerduty/pull/657).

- [Licenses](https://developer.pagerduty.com/api-reference/10230a10c519e-list-license-allocations) are now officially a part of PagerDuty REST API docs: 
- [Create](https://developer.pagerduty.com/api-reference/4cb4fd0f5444a-create-a-user) and Update a User supports a License
- [Fetching a users license](https://developer.pagerduty.com/api-reference/c582c05f8dbd6-get-the-license-allocated-to-a-user)