### PR TITLE
Update `service.responseResponsePlay` to not be omitted if `null`

### DIFF
--- a/pagerduty/automation_actions_action_test.go
+++ b/pagerduty/automation_actions_action_test.go
@@ -96,7 +96,7 @@ func TestAutomationActionsActionTypeProcessAutomationCreate(t *testing.T) {
 	adf := AutomationActionsActionDataReference{
 		ProcessAutomationJobId:        &job_id,
 		ProcessAutomationJobArguments: &adf_arg,
-		ProcessAutomationNodeFilter: &adf_node_filter,
+		ProcessAutomationNodeFilter:   &adf_node_filter,
 	}
 	input := &AutomationActionsAction{
 		Name:                "Action created by TF",

--- a/pagerduty/service.go
+++ b/pagerduty/service.go
@@ -140,7 +140,7 @@ type Service struct {
 	CreatedAt                        string                            `json:"created_at,omitempty"`
 	Description                      string                            `json:"description,omitempty"`
 	EscalationPolicy                 *EscalationPolicyReference        `json:"escalation_policy,omitempty"`
-	ResponsePlay                     *ResponsePlayReference            `json:"response_play,omitempty"`
+	ResponsePlay                     *ResponsePlayReference            `json:"response_play"`
 	HTMLURL                          string                            `json:"html_url,omitempty"`
 	ID                               string                            `json:"id,omitempty"`
 	IncidentUrgencyRule              *IncidentUrgencyRule              `json:"incident_urgency_rule,omitempty"`


### PR DESCRIPTION
Omitting this field on the request will cause no-op update for service's response play configuration. However the API response would be successful leading to a false state change on the Provider.

Also formats `automation_actions_action_test.go` as result of executing `make fmt`.