### PR TITLE
Custom Fields - remove custom fields early access header

### DIFF
--- a/pagerduty/incident_custom_field.go
+++ b/pagerduty/incident_custom_field.go
@@ -121,12 +121,6 @@ type GetIncidentCustomFieldOptions struct {
 	Includes []string `url:"include,brackets,omitempty"`
 }
 
-var incidentCustomFieldsEarlyAccessHeader = RequestOptions{
-	Type:  "header",
-	Label: "X-EARLY-ACCESS",
-	Value: "flex-service-early-access",
-}
-
 // ListContext lists existing custom fields. If a non-zero Limit is passed as an option, only a single page of results will be
 // returned. Otherwise, the entire list of fields will be returned.
 func (s *IncidentCustomFieldService) ListContext(ctx context.Context, o *ListIncidentCustomFieldOptions) (*ListIncidentCustomFieldResponse, *Response, error) {
@@ -137,7 +131,7 @@ func (s *IncidentCustomFieldService) ListContext(ctx context.Context, o *ListInc
 		o = &ListIncidentCustomFieldOptions{}
 	}
 
-	resp, err := s.client.newRequestDoOptionsContext(ctx, "GET", u, o, nil, v, incidentCustomFieldsEarlyAccessHeader)
+	resp, err := s.client.newRequestDoContext(ctx, "GET", u, o, nil, v)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -150,7 +144,7 @@ func (s *IncidentCustomFieldService) GetContext(ctx context.Context, id string, 
 	u := fmt.Sprintf("/incidents/custom_fields/%s", id)
 	v := new(IncidentCustomFieldPayload)
 
-	resp, err := s.client.newRequestDoOptionsContext(ctx, "GET", u, o, nil, v, incidentCustomFieldsEarlyAccessHeader)
+	resp, err := s.client.newRequestDoContext(ctx, "GET", u, o, nil, v)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -163,7 +157,7 @@ func (s *IncidentCustomFieldService) CreateContext(ctx context.Context, field *I
 	u := "/incidents/custom_fields"
 	v := new(IncidentCustomFieldPayload)
 
-	resp, err := s.client.newRequestDoOptionsContext(ctx, "POST", u, nil, &IncidentCustomFieldPayload{Field: field}, &v, incidentCustomFieldsEarlyAccessHeader)
+	resp, err := s.client.newRequestDoContext(ctx, "POST", u, nil, &IncidentCustomFieldPayload{Field: field}, &v)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -174,7 +168,7 @@ func (s *IncidentCustomFieldService) CreateContext(ctx context.Context, field *I
 // DeleteContext removes an existing custom field.
 func (s *IncidentCustomFieldService) DeleteContext(ctx context.Context, id string) (*Response, error) {
 	u := fmt.Sprintf("/incidents/custom_fields/%s", id)
-	return s.client.newRequestDoOptionsContext(ctx, "DELETE", u, nil, nil, nil, incidentCustomFieldsEarlyAccessHeader)
+	return s.client.newRequestDoContext(ctx, "DELETE", u, nil, nil, nil)
 }
 
 // UpdateContext updates an existing custom field.
@@ -182,7 +176,7 @@ func (s *IncidentCustomFieldService) UpdateContext(ctx context.Context, id strin
 	u := fmt.Sprintf("/incidents/custom_fields/%s", id)
 	v := new(IncidentCustomFieldPayload)
 
-	resp, err := s.client.newRequestDoOptionsContext(ctx, "PUT", u, nil, &IncidentCustomFieldPayload{Field: field}, &v, incidentCustomFieldsEarlyAccessHeader)
+	resp, err := s.client.newRequestDoContext(ctx, "PUT", u, nil, &IncidentCustomFieldPayload{Field: field}, &v)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pagerduty/incident_custom_field_option.go
+++ b/pagerduty/incident_custom_field_option.go
@@ -33,7 +33,7 @@ func (s *IncidentCustomFieldService) CreateFieldOptionContext(ctx context.Contex
 	u := fmt.Sprintf("/incidents/custom_fields/%s/field_options", fieldID)
 	v := new(IncidentCustomFieldOptionPayload)
 
-	resp, err := s.client.newRequestDoOptionsContext(ctx, "POST", u, nil, &IncidentCustomFieldOptionPayload{FieldOption: fieldOption}, &v, incidentCustomFieldsEarlyAccessHeader)
+	resp, err := s.client.newRequestDoContext(ctx, "POST", u, nil, &IncidentCustomFieldOptionPayload{FieldOption: fieldOption}, &v)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -46,7 +46,7 @@ func (s *IncidentCustomFieldService) UpdateFieldOptionContext(ctx context.Contex
 	u := fmt.Sprintf("/incidents/custom_fields/%s/field_options/%s", fieldID, fieldOptionID)
 	v := new(IncidentCustomFieldOptionPayload)
 
-	resp, err := s.client.newRequestDoOptionsContext(ctx, "PUT", u, nil, &IncidentCustomFieldOptionPayload{FieldOption: fieldOption}, &v, incidentCustomFieldsEarlyAccessHeader)
+	resp, err := s.client.newRequestDoContext(ctx, "PUT", u, nil, &IncidentCustomFieldOptionPayload{FieldOption: fieldOption}, &v)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -75,7 +75,7 @@ func (s *IncidentCustomFieldService) ListFieldOptionsContext(ctx context.Context
 	u := fmt.Sprintf("/incidents/custom_fields/%s/field_options", fieldID)
 	v := new(ListIncidentCustomFieldOptionsResponse)
 
-	resp, err := s.client.newRequestDoOptionsContext(ctx, "GET", u, nil, nil, &v, incidentCustomFieldsEarlyAccessHeader)
+	resp, err := s.client.newRequestDoContext(ctx, "GET", u, nil, nil, &v)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -86,5 +86,5 @@ func (s *IncidentCustomFieldService) ListFieldOptionsContext(ctx context.Context
 // DeleteFieldOptionContext disables an existing field option.
 func (s *IncidentCustomFieldService) DeleteFieldOptionContext(ctx context.Context, fieldID string, fieldOptionID string) (*Response, error) {
 	u := fmt.Sprintf("/incidents/custom_fields/%s/field_options/%s", fieldID, fieldOptionID)
-	return s.client.newRequestDoOptionsContext(ctx, "DELETE", u, nil, nil, nil, incidentCustomFieldsEarlyAccessHeader)
+	return s.client.newRequestDoContext(ctx, "DELETE", u, nil, nil, nil)
 }


### PR DESCRIPTION
Custom Fields are now generally available and the early access header is no longer needed.