### PR TITLE
Fix user agent hardcoded

### DIFF
--- a/pagerduty/pagerduty.go
+++ b/pagerduty/pagerduty.go
@@ -15,7 +15,8 @@ import (
 )
 
 const (
-	defaultBaseURL = "https://api.pagerduty.com"
+	defaultBaseURL   = "https://api.pagerduty.com"
+	defaultUserAgent = "heimweh/go-pagerduty(terraform)"
 )
 
 type service struct {
@@ -96,7 +97,9 @@ func NewClient(config *Config) (*Client, error) {
 		config.BaseURL = defaultBaseURL
 	}
 
-	config.UserAgent = "heimweh/go-pagerduty(terraform)"
+	if config.UserAgent == "" {
+		config.UserAgent = defaultUserAgent
+	}
 
 	baseURL, err := url.Parse(config.BaseURL)
 	if err != nil {
@@ -186,10 +189,8 @@ func (c *Client) newRequestContext(ctx context.Context, method, url string, body
 	req.Header.Add("Accept", "application/vnd.pagerduty+json;version=2")
 	req.Header.Add("Authorization", fmt.Sprintf("Token token=%s", c.Config.Token))
 	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("User-Agent", c.Config.UserAgent)
 
-	if c.Config.UserAgent != "" {
-		req.Header.Add("User-Agent", c.Config.UserAgent)
-	}
 	return req, nil
 }
 

--- a/pagerduty/pagerduty_test.go
+++ b/pagerduty/pagerduty_test.go
@@ -78,3 +78,25 @@ func testQueryCount(t *testing.T, r *http.Request, count int) {
 		t.Errorf("Request contained unexpected number of query params: %v, want exactly %v", l, count)
 	}
 }
+func TestClientUserAgentDefault(t *testing.T) {
+	client, err := NewClient(&Config{Token: "foo"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if client.Config.UserAgent != defaultUserAgent {
+		t.Errorf("got %q, want %q", client.Config.UserAgent, defaultUserAgent)
+	}
+}
+
+func TestClientUserAgentOverwritten(t *testing.T) {
+	newUserAgent := "foo-user-agent"
+	client, err := NewClient(&Config{Token: "foo", UserAgent: newUserAgent})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if client.Config.UserAgent != newUserAgent {
+		t.Errorf("got %q, want %q", client.Config.UserAgent, newUserAgent)
+	}
+}


### PR DESCRIPTION
Update meant to address user agent being hardcoded in Client configuration, therefore User Agent overwrites will now take effect.

## New tests cases introduced...

```sh
$ make test TESTARGS="-v -run ClientUserAgent"
==> Testing go-pagerduty
=== RUN   TestClientUserAgentDefault
2023/06/30 11:01:41 ===== PagerDuty Cache Skipping Init =====
--- PASS: TestClientUserAgentDefault (0.00s)
=== RUN   TestClientUserAgentOverwritten
2023/06/30 11:01:41 ===== PagerDuty Cache Skipping Init =====
--- PASS: TestClientUserAgentOverwritten (0.00s)
PASS
ok      github.com/heimweh/go-pagerduty/pagerduty       0.182s
```