### PR TITLE
Add support for Incident Custom Fields and sanitize Orchestration PUT request

### DIFF
--- a/pagerduty/event_orchestration_path.go
+++ b/pagerduty/event_orchestration_path.go
@@ -59,10 +59,16 @@ type EventOrchestrationPathRuleActions struct {
 	Annotate                   string                                             `json:"annotate"`
 	PagerdutyAutomationActions []*EventOrchestrationPathPagerdutyAutomationAction `json:"pagerduty_automation_actions"`
 	AutomationActions          []*EventOrchestrationPathAutomationAction          `json:"automation_actions"`
+	IncidentCustomFieldActions []*EventOrchestrationPathIncidentCustomFieldAction `json:"incident_custom_field_updates"`
 	Severity                   string                                             `json:"severity"`
 	EventAction                string                                             `json:"event_action"`
 	Variables                  []*EventOrchestrationPathActionVariables           `json:"variables"`
 	Extractions                []*EventOrchestrationPathActionExtractions         `json:"extractions"`
+}
+
+type EventOrchestrationPathIncidentCustomFieldAction struct {
+	ID string `json:"id,omitempty"`
+	Value string `json:"value,omitempty"`
 }
 
 type EventOrchestrationPathPagerdutyAutomationAction struct {

--- a/pagerduty/event_orchestration_path.go
+++ b/pagerduty/event_orchestration_path.go
@@ -59,14 +59,14 @@ type EventOrchestrationPathRuleActions struct {
 	Annotate                   string                                             `json:"annotate"`
 	PagerdutyAutomationActions []*EventOrchestrationPathPagerdutyAutomationAction `json:"pagerduty_automation_actions"`
 	AutomationActions          []*EventOrchestrationPathAutomationAction          `json:"automation_actions"`
-	IncidentCustomFieldActions []*EventOrchestrationPathIncidentCustomFieldAction `json:"incident_custom_field_updates"`
+	IncidentCustomFieldUpdates []*EventOrchestrationPathIncidentCustomFieldUpdate `json:"incident_custom_field_updates"`
 	Severity                   string                                             `json:"severity"`
 	EventAction                string                                             `json:"event_action"`
 	Variables                  []*EventOrchestrationPathActionVariables           `json:"variables"`
 	Extractions                []*EventOrchestrationPathActionExtractions         `json:"extractions"`
 }
 
-type EventOrchestrationPathIncidentCustomFieldAction struct {
+type EventOrchestrationPathIncidentCustomFieldUpdate struct {
 	ID string `json:"id,omitempty"`
 	Value string `json:"value,omitempty"`
 }
@@ -206,8 +206,8 @@ func sanitizeOrchestrationPath(servicePath *EventOrchestrationPath)  {
 
 // Sanitize the actions to ensure that the arrays are not null
 func sanitizeActions(actions *EventOrchestrationPathRuleActions) {
-	if actions.IncidentCustomFieldActions == nil {
-		actions.IncidentCustomFieldActions = []*EventOrchestrationPathIncidentCustomFieldAction{}
+	if actions.IncidentCustomFieldUpdates == nil {
+		actions.IncidentCustomFieldUpdates = []*EventOrchestrationPathIncidentCustomFieldUpdate{}
 	}
 	if actions.AutomationActions == nil {
 		actions.AutomationActions = []*EventOrchestrationPathAutomationAction{}

--- a/pagerduty/event_orchestration_path.go
+++ b/pagerduty/event_orchestration_path.go
@@ -57,13 +57,13 @@ type EventOrchestrationPathRuleActions struct {
 	Suspend                    *int                                               `json:"suspend"`
 	Priority                   string                                             `json:"priority"`
 	Annotate                   string                                             `json:"annotate"`
-	PagerdutyAutomationActions []*EventOrchestrationPathPagerdutyAutomationAction `json:"pagerduty_automation_actions,omitempty"`
-	AutomationActions          []*EventOrchestrationPathAutomationAction          `json:"automation_actions,omitempty"`
-	IncidentCustomFieldActions []*EventOrchestrationPathIncidentCustomFieldAction `json:"incident_custom_field_updates,omitempty"`
+	PagerdutyAutomationActions []*EventOrchestrationPathPagerdutyAutomationAction `json:"pagerduty_automation_actions"`
+	AutomationActions          []*EventOrchestrationPathAutomationAction          `json:"automation_actions"`
+	IncidentCustomFieldActions []*EventOrchestrationPathIncidentCustomFieldAction `json:"incident_custom_field_updates"`
 	Severity                   string                                             `json:"severity"`
 	EventAction                string                                             `json:"event_action"`
-	Variables                  []*EventOrchestrationPathActionVariables           `json:"variables,omitempty"`
-	Extractions                []*EventOrchestrationPathActionExtractions         `json:"extractions,omitempty"`
+	Variables                  []*EventOrchestrationPathActionVariables           `json:"variables"`
+	Extractions                []*EventOrchestrationPathActionExtractions         `json:"extractions"`
 }
 
 type EventOrchestrationPathIncidentCustomFieldAction struct {

--- a/pagerduty/event_orchestration_path.go
+++ b/pagerduty/event_orchestration_path.go
@@ -194,10 +194,14 @@ func sanitizeOrchestrationPath(servicePath *EventOrchestrationPath)  {
 			if rule.Conditions == nil {
 				rule.Conditions = []*EventOrchestrationPathRuleCondition{}
 			}
-			sanitizeActions(rule.Actions)
+			if rule.Actions != nil {
+				sanitizeActions(rule.Actions)
+			}
 		}
 	}
-	sanitizeActions(servicePath.CatchAll.Actions)
+	if (servicePath.CatchAll != nil) {
+		sanitizeActions(servicePath.CatchAll.Actions)
+	}
 }
 
 // Sanitize the actions to ensure that the arrays are not null

--- a/pagerduty/event_orchestration_path.go
+++ b/pagerduty/event_orchestration_path.go
@@ -176,6 +176,7 @@ func (s *EventOrchestrationPathService) Update(id string, pathType string, orche
 func (s *EventOrchestrationPathService) UpdateContext(ctx context.Context, id string, pathType string, orchestrationPath *EventOrchestrationPath) (*EventOrchestrationPathPayload, *Response, error) {
 	u := orchestrationPathUrlBuilder(id, pathType)
 	v := new(EventOrchestrationPathPayload)
+	sanitizeOrchestrationPath(orchestrationPath)
 	p := EventOrchestrationPathPayload{OrchestrationPath: orchestrationPath}
 
 	resp, err := s.client.newRequestDoContext(ctx, "PUT", u, nil, p, &v)
@@ -184,6 +185,38 @@ func (s *EventOrchestrationPathService) UpdateContext(ctx context.Context, id st
 	}
 
 	return v, resp, nil
+}
+
+// Sanitize the conditions and actions to ensure that the arrays are not null
+func sanitizeOrchestrationPath(servicePath *EventOrchestrationPath)  {
+	for _, set := range servicePath.Sets {
+		for _, rule := range set.Rules {
+			if rule.Conditions == nil {
+				rule.Conditions = []*EventOrchestrationPathRuleCondition{}
+			}
+			sanitizeActions(rule.Actions)
+		}
+	}
+	sanitizeActions(servicePath.CatchAll.Actions)
+}
+
+// Sanitize the actions to ensure that the arrays are not null
+func sanitizeActions(actions *EventOrchestrationPathRuleActions) {
+	if actions.IncidentCustomFieldActions == nil {
+		actions.IncidentCustomFieldActions = []*EventOrchestrationPathIncidentCustomFieldAction{}
+	}
+	if actions.AutomationActions == nil {
+		actions.AutomationActions = []*EventOrchestrationPathAutomationAction{}
+	}
+	if actions.PagerdutyAutomationActions == nil {
+		actions.PagerdutyAutomationActions = []*EventOrchestrationPathPagerdutyAutomationAction{}
+	}
+	if actions.Variables == nil {
+		actions.Variables = []*EventOrchestrationPathActionVariables{}
+	}
+	if actions.Extractions == nil {
+		actions.Extractions = []*EventOrchestrationPathActionExtractions{}
+	}
 }
 
 // UpdateServiceActiveStatus for EventOrchestrationPath

--- a/pagerduty/event_orchestration_path.go
+++ b/pagerduty/event_orchestration_path.go
@@ -57,13 +57,13 @@ type EventOrchestrationPathRuleActions struct {
 	Suspend                    *int                                               `json:"suspend"`
 	Priority                   string                                             `json:"priority"`
 	Annotate                   string                                             `json:"annotate"`
-	PagerdutyAutomationActions []*EventOrchestrationPathPagerdutyAutomationAction `json:"pagerduty_automation_actions"`
-	AutomationActions          []*EventOrchestrationPathAutomationAction          `json:"automation_actions"`
-	IncidentCustomFieldActions []*EventOrchestrationPathIncidentCustomFieldAction `json:"incident_custom_field_updates"`
+	PagerdutyAutomationActions []*EventOrchestrationPathPagerdutyAutomationAction `json:"pagerduty_automation_actions,omitempty"`
+	AutomationActions          []*EventOrchestrationPathAutomationAction          `json:"automation_actions,omitempty"`
+	IncidentCustomFieldActions []*EventOrchestrationPathIncidentCustomFieldAction `json:"incident_custom_field_updates,omitempty"`
 	Severity                   string                                             `json:"severity"`
 	EventAction                string                                             `json:"event_action"`
-	Variables                  []*EventOrchestrationPathActionVariables           `json:"variables"`
-	Extractions                []*EventOrchestrationPathActionExtractions         `json:"extractions"`
+	Variables                  []*EventOrchestrationPathActionVariables           `json:"variables,omitempty"`
+	Extractions                []*EventOrchestrationPathActionExtractions         `json:"extractions,omitempty"`
 }
 
 type EventOrchestrationPathIncidentCustomFieldAction struct {

--- a/pagerduty/event_orchestration_path.go
+++ b/pagerduty/event_orchestration_path.go
@@ -176,7 +176,6 @@ func (s *EventOrchestrationPathService) Update(id string, pathType string, orche
 func (s *EventOrchestrationPathService) UpdateContext(ctx context.Context, id string, pathType string, orchestrationPath *EventOrchestrationPath) (*EventOrchestrationPathPayload, *Response, error) {
 	u := orchestrationPathUrlBuilder(id, pathType)
 	v := new(EventOrchestrationPathPayload)
-	sanitizeOrchestrationPath(orchestrationPath)
 	p := EventOrchestrationPathPayload{OrchestrationPath: orchestrationPath}
 
 	resp, err := s.client.newRequestDoContext(ctx, "PUT", u, nil, p, &v)
@@ -185,42 +184,6 @@ func (s *EventOrchestrationPathService) UpdateContext(ctx context.Context, id st
 	}
 
 	return v, resp, nil
-}
-
-// Sanitize the conditions and actions to ensure that the arrays are not null
-func sanitizeOrchestrationPath(servicePath *EventOrchestrationPath)  {
-	for _, set := range servicePath.Sets {
-		for _, rule := range set.Rules {
-			if rule.Conditions == nil {
-				rule.Conditions = []*EventOrchestrationPathRuleCondition{}
-			}
-			if rule.Actions != nil {
-				sanitizeActions(rule.Actions)
-			}
-		}
-	}
-	if (servicePath.CatchAll != nil) {
-		sanitizeActions(servicePath.CatchAll.Actions)
-	}
-}
-
-// Sanitize the actions to ensure that the arrays are not null
-func sanitizeActions(actions *EventOrchestrationPathRuleActions) {
-	if actions.IncidentCustomFieldUpdates == nil {
-		actions.IncidentCustomFieldUpdates = []*EventOrchestrationPathIncidentCustomFieldUpdate{}
-	}
-	if actions.AutomationActions == nil {
-		actions.AutomationActions = []*EventOrchestrationPathAutomationAction{}
-	}
-	if actions.PagerdutyAutomationActions == nil {
-		actions.PagerdutyAutomationActions = []*EventOrchestrationPathPagerdutyAutomationAction{}
-	}
-	if actions.Variables == nil {
-		actions.Variables = []*EventOrchestrationPathActionVariables{}
-	}
-	if actions.Extractions == nil {
-		actions.Extractions = []*EventOrchestrationPathActionExtractions{}
-	}
 }
 
 // UpdateServiceActiveStatus for EventOrchestrationPath

--- a/pagerduty/event_orchestration_path_test.go
+++ b/pagerduty/event_orchestration_path_test.go
@@ -331,6 +331,19 @@ func TestEventOrchestrationPathGlobalUpdate(t *testing.T) {
 						ID:    "4ad2c1be",
 						Label: "business hours",
 					},
+					{
+						Actions: &EventOrchestrationPathRuleActions{
+							IncidentCustomFieldActions: []*EventOrchestrationPathIncidentCustomFieldAction{
+								{
+									ID:    "PN1C4A2",
+									Value: "{{event.timestamp}}",
+								},
+							},
+						},
+						Label: "Set Impact Start custom field from event",
+						ID:   "yu3bv02m",
+						Conditions: []*EventOrchestrationPathRuleCondition{},
+					},
 				},
 			},
 			{
@@ -408,6 +421,19 @@ func TestEventOrchestrationPathGlobalUpdate(t *testing.T) {
 								"conditions": [{"expression": "now in Mon,Tue,Wed,Thu,Fri 08:00:00 to 18:00:00 America/Los_Angeles"}],
 								"id": "4ad2c1be",
 								"label": "business hours"
+							},
+							{
+								"label": "Set Impact Start custom field from event",
+								"id": "yu3bv02m",
+								"conditions": [],
+								"actions": {
+								"incident_custom_field_updates": [
+									{
+									"id": "PN1C4A2",
+									"value": "{{event.timestamp}}"
+									}
+								]
+								}
 							}
 						]
 					},
@@ -601,14 +627,14 @@ func TestEventOrchestrationPathUnroutedUpdate(t *testing.T) {
 			},
 		},
 		Warnings: []*EventOrchestrationPathWarning{
-			&EventOrchestrationPathWarning{
+			{
 				Feature:     "variables",
 				FeatureType: "actions",
 				Message:     "Message 1",
 				RuleId:      "abcd001",
 				WarningType: "forbidden_feature",
 			},
-			&EventOrchestrationPathWarning{
+			{
 				Feature:     "extractions",
 				FeatureType: "actions",
 				Message:     "Message 2",

--- a/pagerduty/event_orchestration_path_test.go
+++ b/pagerduty/event_orchestration_path_test.go
@@ -250,6 +250,55 @@ func TestEventOrchestrationPathGetServiceActiveStatus(t *testing.T) {
 	}
 }
 
+func TestEventOrchestationSanitization(t *testing.T) {
+	setup()
+	defer teardown()
+
+	input := &EventOrchestrationPath{
+		Sets: []*EventOrchestrationPathSet{
+			{
+				ID: "start",
+				Rules: []*EventOrchestrationPathRule{
+					{
+						Actions: &EventOrchestrationPathRuleActions{},
+					},
+				},
+			},
+		},
+	}
+
+	var url = fmt.Sprintf("%s/E-ORC-1/global", eventOrchestrationBaseUrl)
+
+	mux.HandleFunc(url, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		v := new(EventOrchestrationPathPayload)
+		json.NewDecoder(r.Body).Decode(v)
+		if !reflect.DeepEqual(v.OrchestrationPath, input) {
+			t.Errorf("Request body = %+v, want %+v", v, input)
+		}
+		w.Write([]byte(`{}`))
+	})
+
+	// empty arrays are null by default
+	actionJson, _ := json.Marshal(input.Sets[0].Rules[0].Actions.PagerdutyAutomationActions)
+	want := "null"
+	if !reflect.DeepEqual(string(actionJson), want) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", string(actionJson), want)
+	}
+	reflect.DeepEqual(actionJson, nil)
+	_, _, err := client.EventOrchestrationPaths.Update("E-ORC-1", PathTypeGlobal, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// after sanitize, empty arrays are no longer null
+	actionJson, _ = json.Marshal(input.Sets[0].Rules[0].Actions.PagerdutyAutomationActions)
+	want = "[]"
+	if !reflect.DeepEqual(string(actionJson), want) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", string(actionJson), want)
+	}
+
+}
+
 func TestEventOrchestrationPathGlobalUpdate(t *testing.T) {
 	setup()
 	defer teardown()
@@ -488,6 +537,9 @@ func TestEventOrchestrationPathGlobalUpdate(t *testing.T) {
 			Version: "AbCdE.5",
 		},
 	}
+
+	// Before comparison, we sanitize the response to make it match the already sanitized request
+	sanitizeOrchestrationPath(resp.OrchestrationPath)
 
 	if !reflect.DeepEqual(resp, want) {
 		t.Errorf("returned \n\n%#v want \n\n%#v", resp, want)

--- a/pagerduty/event_orchestration_path_test.go
+++ b/pagerduty/event_orchestration_path_test.go
@@ -382,7 +382,7 @@ func TestEventOrchestrationPathGlobalUpdate(t *testing.T) {
 					},
 					{
 						Actions: &EventOrchestrationPathRuleActions{
-							IncidentCustomFieldActions: []*EventOrchestrationPathIncidentCustomFieldAction{
+							IncidentCustomFieldUpdates: []*EventOrchestrationPathIncidentCustomFieldUpdate{
 								{
 									ID:    "PN1C4A2",
 									Value: "{{event.timestamp}}",
@@ -424,7 +424,7 @@ func TestEventOrchestrationPathGlobalUpdate(t *testing.T) {
 		if !reflect.DeepEqual(v.OrchestrationPath, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
-		actionJson, _ := json.Marshal(input.Sets[0].Rules[0].Actions.IncidentCustomFieldActions)
+		actionJson, _ := json.Marshal(input.Sets[0].Rules[0].Actions.IncidentCustomFieldUpdates)
 		if !reflect.DeepEqual(string(actionJson), "[]") {
 			t.Errorf("empty action array should be []")
 		}

--- a/pagerduty/event_orchestration_path_test.go
+++ b/pagerduty/event_orchestration_path_test.go
@@ -424,6 +424,10 @@ func TestEventOrchestrationPathGlobalUpdate(t *testing.T) {
 		if !reflect.DeepEqual(v.OrchestrationPath, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
+		actionJson, _ := json.Marshal(input.Sets[0].Rules[0].Actions.IncidentCustomFieldActions)
+		if !reflect.DeepEqual(string(actionJson), "[]") {
+			t.Errorf("empty action array should be []")
+		}
 		w.Write([]byte(`{
 			"orchestration_path": {
 				"catch_all": {"actions": {"suppress": true}},


### PR DESCRIPTION
This PR adds support for Incident Custom Fields on the Event Orchestration path. This feature will be released in January 2024. In addition it fixes the API call for updating the Event Orchestration.

Changes:

- Added new `EventOrchestrationPathIncidentCustomFieldUpdate` struct which is an ID/Value pair of the custom field
- Added this new property to existing `EventOrchestrationPathRuleActions` struct
- Updated test in `pagerduty/event_orchestration_path_test.go` for new action type
- In the process of testing Getting/Saving a Service Orchestration, I determined there was a bug in this client where it was sending `null` values for arrays. This is not allowed by the API and results in an HTTP 400 Bad Request. I've added functions `sanitizeOrchestrationPath` and `sanitizeActions`  to replace null values with empty arrays. 

The following is a test client I wrote to test this library. The code below simply gets the service orchestration and then updates it with the same object from the get request. Without the sanitize change, this library throws an error.

```
func main() {
	client, err := pagerduty.NewClient(&pagerduty.Config{
		Token: os.Getenv("PAGERDUTY_TOKEN")})
	if err != nil {
		panic(err)
	}

	servicesResp, _, err := client.Services.List(&pagerduty.ListServicesOptions{})
	if err != nil {
		panic(err)
	}
	serviceId := servicesResp.Services[0].ID
	
	servicePathResp, _, err := client.EventOrchestrationPaths.Get(serviceId, "service")
	if err != nil {
		panic(err)
	}
	
	updatePayload, _, err := client.EventOrchestrationPaths.Update(serviceId, "service", servicePathResp)
	if err != nil {
		panic(err)
	}

}

```
