### PR TITLE
incident_workflow.go: add support for inline_steps_inputs

### DIFF
--- a/pagerduty/incident_workflow.go
+++ b/pagerduty/incident_workflow.go
@@ -31,14 +31,33 @@ type IncidentWorkflowStep struct {
 
 // IncidentWorkflowActionConfiguration represents the configuration for an incident workflow action
 type IncidentWorkflowActionConfiguration struct {
-	ActionID    string                         `json:"action_id,omitempty"`
-	Description *string                        `json:"description,omitempty"`
-	Inputs      []*IncidentWorkflowActionInput `json:"inputs,omitempty"`
+	ActionID          string                                    `json:"action_id,omitempty"`
+	Description       *string                                   `json:"description,omitempty"`
+	Inputs            []*IncidentWorkflowActionInput            `json:"inputs,omitempty"`
+	InlineStepsInputs []*IncidentWorkflowActionInlineStepsInput `json:"inline_steps_inputs,omitempty"`
 }
 
+// IncidentWorkflowActionInput represents the configuration for an incident workflow action input with a serialized string as the value
 type IncidentWorkflowActionInput struct {
 	Name  string `json:"name,omitempty"`
 	Value string `json:"value,omitempty"`
+}
+
+// IncidentWorkflowActionInlineStepsInput represents the configuration for an incident workflow action input with a series of inlined steps as the value
+type IncidentWorkflowActionInlineStepsInput struct {
+	Name  string `json:"name,omitempty"`
+	Value *IncidentWorkflowActionInlineStepsInputValue `json:"value,omitempty"`
+}
+
+// IncidentWorkflowActionInlineStepsInputValue represents the value for an inline_steps_input input
+type IncidentWorkflowActionInlineStepsInputValue struct {
+	Steps []*IncidentWorkflowActionInlineStep `json:"steps,omitempty"`
+}
+
+// IncidentWorkflowActionInlineStep represents a single step within an inline_steps_input input's value
+type IncidentWorkflowActionInlineStep struct {
+	Name          string                               `json:"name,omitempty"`
+	Configuration *IncidentWorkflowActionConfiguration `json:"action_configuration,omitempty"`
 }
 
 // ListIncidentWorkflowResponse represents a list response of incident workflows.

--- a/pagerduty/incident_workflow_test.go
+++ b/pagerduty/incident_workflow_test.go
@@ -239,6 +239,27 @@ func TestIncidentWorkflowGet(t *testing.T) {
                     "value": "{{ example-value }}"
                 }
             ],
+            "inline_steps_inputs": [
+                {
+                    "name": "Example inline_steps_input",
+                    "value": {
+                        "steps": [
+                            {
+                                "name": "Inline Step 1",
+                                "action_configuration": {
+                                    "action_id": "example/action/v1",
+                                    "inputs": [
+                                        {
+                                            "name": "Example input",
+                                            "value": "B"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ],
             "outputs": [
                 {
                     "name": "Example output",
@@ -305,6 +326,27 @@ func TestIncidentWorkflowGet(t *testing.T) {
 							Value: "{{ example-value }}",
 						},
 					},
+					InlineStepsInputs: []*IncidentWorkflowActionInlineStepsInput{
+						{
+							Name:  "Example inline_steps_input",
+							Value: &IncidentWorkflowActionInlineStepsInputValue{
+								Steps: []*IncidentWorkflowActionInlineStep{
+									{
+										Name:        "Inline Step 1",
+										Configuration: &IncidentWorkflowActionConfiguration{
+											ActionID:    "example/action/v1",
+											Inputs: []*IncidentWorkflowActionInput{
+												{
+													Name:  "Example input",
+													Value: "B",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 		},
@@ -321,7 +363,7 @@ func TestIncidentWorkflowCreate(t *testing.T) {
 
 	mux.HandleFunc("/incident_workflows", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		testBody(t, r, `{"incident_workflow":{"name":"Example Workflow","description":"This workflow serves as an example","steps":[{"name":"Example Step","description":"An example workflow step","action_configuration":{"action_id":"example/action/v1","inputs":[{"name":"Example input","value":"{{ example-value }}"}]}},{"name":"Subsequent Step","description":"A subsequent step in this workflow","action_configuration":{"action_id":"example/action/v1","inputs":[{"name":"Example input","value":"{{ example-value }}"}]}}]}}`)
+		testBody(t, r, `{"incident_workflow":{"name":"Example Workflow","description":"This workflow serves as an example","steps":[{"name":"Example Step","description":"An example workflow step","action_configuration":{"action_id":"example/action/v1","inputs":[{"name":"Example input","value":"{{ example-value }}"}]}},{"name":"Subsequent Step","description":"A subsequent step in this workflow","action_configuration":{"action_id":"example/action/v1","inputs":[{"name":"Example input","value":"{{ example-value }}"}],"inline_steps_inputs":[{"name":"Example inline_steps_input","value":{"steps":[{"name":"Inline Step 1","action_configuration":{"action_id":"example/action/v1","inputs":[{"name":"Example input","value":"B"}]}}]}}]}}]}}`)
 
 		w.Write([]byte(`
 {
@@ -374,6 +416,27 @@ func TestIncidentWorkflowCreate(t *testing.T) {
                     "value": "{{ example-value }}"
                 }
             ],
+            "inline_steps_inputs": [
+                {
+                    "name": "Example inline_steps_input",
+                    "value": {
+                        "steps": [
+                            {
+                                "name": "Inline Step 1",
+                                "action_configuration": {
+                                    "action_id": "example/action/v1",
+                                    "inputs": [
+                                        {
+                                            "name": "Example input",
+                                            "value": "B"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ],
             "outputs": [
                 {
                     "name": "Example output",
@@ -422,6 +485,27 @@ func TestIncidentWorkflowCreate(t *testing.T) {
 							Value: "{{ example-value }}",
 						},
 					},
+					InlineStepsInputs: []*IncidentWorkflowActionInlineStepsInput{
+						{
+							Name:  "Example inline_steps_input",
+							Value: &IncidentWorkflowActionInlineStepsInputValue{
+								Steps: []*IncidentWorkflowActionInlineStep{
+									{
+										Name:        "Inline Step 1",
+										Configuration: &IncidentWorkflowActionConfiguration{
+											ActionID:    "example/action/v1",
+											Inputs: []*IncidentWorkflowActionInput{
+												{
+													Name:  "Example input",
+													Value: "B",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 		},
@@ -466,6 +550,27 @@ func TestIncidentWorkflowCreate(t *testing.T) {
 							Value: "{{ example-value }}",
 						},
 					},
+					InlineStepsInputs: []*IncidentWorkflowActionInlineStepsInput{
+						{
+							Name:  "Example inline_steps_input",
+							Value: &IncidentWorkflowActionInlineStepsInputValue{
+								Steps: []*IncidentWorkflowActionInlineStep{
+									{
+										Name:        "Inline Step 1",
+										Configuration: &IncidentWorkflowActionConfiguration{
+											ActionID:    "example/action/v1",
+											Inputs: []*IncidentWorkflowActionInput{
+												{
+													Name:  "Example input",
+													Value: "B",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 		},
@@ -501,7 +606,7 @@ func TestIncidentWorkflowUpdate(t *testing.T) {
 
 	mux.HandleFunc("/incident_workflows/IW1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
-		testBody(t, r, `{"incident_workflow":{"description":"Updated description","steps":[{"id":"32OIHWEJ"},{"id":"D3IT0D3","name":"Subsequent Step Updated Name"}]}}`)
+		testBody(t, r, `{"incident_workflow":{"description":"Updated description","steps":[{"id":"32OIHWEJ"},{"id":"D3IT0D3","name":"Subsequent Step Updated Name","action_configuration":{"action_id":"example/action/v1","inputs":[{"name":"Example input","value":"{{ example-value }}"}],"inline_steps_inputs":[{"name":"Example inline_steps_input","value":{"steps":[{"name":"Inline Step 1 Updated Name","action_configuration":{"action_id":"example/action/v1","inputs":[{"name":"Example input","value":"B"}]}}]}}]}}]}}`)
 
 		w.Write([]byte(`
 {
@@ -554,6 +659,27 @@ func TestIncidentWorkflowUpdate(t *testing.T) {
                     "value": "{{ example-value }}"
                 }
             ],
+            "inline_steps_inputs": [
+                {
+                    "name": "Example inline_steps_input",
+                    "value": {
+                        "steps": [
+                            {
+                                "name": "Inline Step 1 Updated Name",
+                                "action_configuration": {
+                                    "action_id": "example/action/v1",
+                                    "inputs": [
+                                        {
+                                            "name": "Example input",
+                                            "value": "B"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ],
             "outputs": [
                 {
                     "name": "Example output",
@@ -584,6 +710,36 @@ func TestIncidentWorkflowUpdate(t *testing.T) {
 			{
 				ID:   "D3IT0D3",
 				Name: "Subsequent Step Updated Name",
+				Configuration: &IncidentWorkflowActionConfiguration{
+					ActionID: "example/action/v1",
+					Inputs: []*IncidentWorkflowActionInput{
+						{
+							Name:  "Example input",
+							Value: "{{ example-value }}",
+						},
+					},
+					InlineStepsInputs: []*IncidentWorkflowActionInlineStepsInput{
+						{
+							Name:  "Example inline_steps_input",
+							Value: &IncidentWorkflowActionInlineStepsInputValue{
+								Steps: []*IncidentWorkflowActionInlineStep{
+									{
+										Name:        "Inline Step 1 Updated Name",
+										Configuration: &IncidentWorkflowActionConfiguration{
+											ActionID:    "example/action/v1",
+											Inputs: []*IncidentWorkflowActionInput{
+												{
+													Name:  "Example input",
+													Value: "B",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
 			},
 		},
 	})
@@ -625,6 +781,27 @@ func TestIncidentWorkflowUpdate(t *testing.T) {
 						{
 							Name:  "Example input",
 							Value: "{{ example-value }}",
+						},
+					},
+					InlineStepsInputs: []*IncidentWorkflowActionInlineStepsInput{
+						{
+							Name:  "Example inline_steps_input",
+							Value: &IncidentWorkflowActionInlineStepsInputValue{
+								Steps: []*IncidentWorkflowActionInlineStep{
+									{
+										Name:        "Inline Step 1 Updated Name",
+										Configuration: &IncidentWorkflowActionConfiguration{
+											ActionID:    "example/action/v1",
+											Inputs: []*IncidentWorkflowActionInput{
+												{
+													Name:  "Example input",
+													Value: "B",
+												},
+											},
+										},
+									},
+								},
+							},
 						},
 					},
 				},


### PR DESCRIPTION
This update brings support for using `inline_steps_input`s when building Incident Workflows. `inline_steps_input`s are specialized inputs of certain Actions that can be identified by looking for `@metadata.format="inlineSteps".

These specialized inputs diverge from the standard value format of `string`, and instead are composed of a specific schema that allows inline steps to be configured. This allows for a series of inline steps to be executed conditionally, or within a loop, while still being defined as part of a single workflow.