### PR TITLE
fix: do not set query string on request retries

### DIFF
--- a/pagerduty/pagerduty.go
+++ b/pagerduty/pagerduty.go
@@ -336,7 +336,7 @@ func (c *Client) newRequestDoContext(ctx context.Context, method, url string, qr
 	resp, err := c.do(req, v)
 	if err != nil {
 		if respErr, ok := err.(*Error); ok && respErr.needToRetry {
-			return c.newRequestDoContext(ctx, method, url, qryOptions, body, v)
+			return c.newRequestDoContext(ctx, method, url, nil, body, v)
 		}
 
 		return nil, err
@@ -368,7 +368,7 @@ func (c *Client) newRequestDoOptionsContext(ctx context.Context, method, url str
 	resp, err := c.do(req, v)
 	if err != nil {
 		if respErr, ok := err.(*Error); ok && respErr.needToRetry {
-			return c.newRequestDoOptionsContext(ctx, method, url, qryOptions, body, v)
+			return c.newRequestDoOptionsContext(ctx, method, url, nil, body, v)
 		}
 
 		return nil, err


### PR DESCRIPTION
We have run into an issue when using this in the PagerDuty Terraform provider we get malformed URLs when a request with a query string is rate limited.

In our specific case it was a call to `/members?offset=100` would result in `/members?offset=100?offset=100` on the retry, which would cause a 400 to be returned.

The accompanying test shows that the url is the same every time it's called. Before the fix I could see the query string multiplying after every call.