### PR TITLE
changed " to ` because go staticcheck indicated the following issues …

### DIFF
--- a/pagerduty/cache.go
+++ b/pagerduty/cache.go
@@ -57,7 +57,7 @@ type cacheLastRefreshRecord struct {
 func InitCache(c *Client) {
 	pdClient = c
 	cacheMongoURL = os.Getenv("TF_PAGERDUTY_CACHE")
-	re := regexp.MustCompile("^mongodb+(\\+srv)?://")
+	re := regexp.MustCompile(`^mongodb+(\\+srv)?://`)
 	isMongodbURL := re.Match([]byte(cacheMongoURL))
 	if isMongodbURL {
 		log.Printf("===== Enabling PagerDuty Mongo cache at %v", cacheMongoURL)


### PR DESCRIPTION
…in `cache.go`

should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (S1007)go-staticcheck