### PR TITLE
Rule actions updates

### DIFF
--- a/pagerduty/event_orchestration_path.go
+++ b/pagerduty/event_orchestration_path.go
@@ -65,7 +65,7 @@ type EventOrchestrationPathRuleActions struct {
 	EventAction                string                                             `json:"event_action"`
 	Variables                  []*EventOrchestrationPathActionVariables           `json:"variables"`
 	Extractions                []*EventOrchestrationPathActionExtractions         `json:"extractions"`
-	EscalationPolicy           string                                             `json:"escalation_policy"`
+	EscalationPolicy           *string                                            `json:"escalation_policy"`
 }
 
 type EventOrchestrationPathDynamicRouteTo struct {

--- a/pagerduty/event_orchestration_path.go
+++ b/pagerduty/event_orchestration_path.go
@@ -53,6 +53,7 @@ type EventOrchestrationPathRuleCondition struct {
 type EventOrchestrationPathRuleActions struct {
 	DropEvent                  bool                                               `json:"drop_event"`
 	RouteTo                    string                                             `json:"route_to"`
+	DynamicRouteTo             *EventOrchestrationPathDynamicRouteTo              `json:"dynamic_route_to"`
 	Suppress                   bool                                               `json:"suppress"`
 	Suspend                    *int                                               `json:"suspend"`
 	Priority                   string                                             `json:"priority"`
@@ -64,6 +65,12 @@ type EventOrchestrationPathRuleActions struct {
 	EventAction                string                                             `json:"event_action"`
 	Variables                  []*EventOrchestrationPathActionVariables           `json:"variables"`
 	Extractions                []*EventOrchestrationPathActionExtractions         `json:"extractions"`
+}
+
+type EventOrchestrationPathDynamicRouteTo struct {
+	Source   string `json:"source,omitempty"`
+	Regex    string `json:"regex,omitempty"`
+	LookupBy string `json:"lookup_by,omitempty"`
 }
 
 type EventOrchestrationPathIncidentCustomFieldUpdate struct {

--- a/pagerduty/event_orchestration_path.go
+++ b/pagerduty/event_orchestration_path.go
@@ -65,7 +65,7 @@ type EventOrchestrationPathRuleActions struct {
 	EventAction                string                                             `json:"event_action"`
 	Variables                  []*EventOrchestrationPathActionVariables           `json:"variables"`
 	Extractions                []*EventOrchestrationPathActionExtractions         `json:"extractions"`
-	EscalationPolicy           *EventOrchestrationPathEscalationPolicy            `json:"escalation_policy"`
+	EscalationPolicy           string                                             `json:"escalation_policy,omitempty"`
 }
 
 type EventOrchestrationPathDynamicRouteTo struct {
@@ -77,10 +77,6 @@ type EventOrchestrationPathDynamicRouteTo struct {
 type EventOrchestrationPathIncidentCustomFieldUpdate struct {
 	ID    string `json:"id,omitempty"`
 	Value string `json:"value,omitempty"`
-}
-
-type EventOrchestrationPathEscalationPolicy struct {
-	EscalationPolicy string `json:"escalation_policy,omitempty"`
 }
 
 type EventOrchestrationPathPagerdutyAutomationAction struct {

--- a/pagerduty/event_orchestration_path.go
+++ b/pagerduty/event_orchestration_path.go
@@ -65,6 +65,7 @@ type EventOrchestrationPathRuleActions struct {
 	EventAction                string                                             `json:"event_action"`
 	Variables                  []*EventOrchestrationPathActionVariables           `json:"variables"`
 	Extractions                []*EventOrchestrationPathActionExtractions         `json:"extractions"`
+	EscalationPolicy           *EventOrchestrationPathEscalationPolicy            `json:"escalation_policy"`
 }
 
 type EventOrchestrationPathDynamicRouteTo struct {
@@ -76,6 +77,10 @@ type EventOrchestrationPathDynamicRouteTo struct {
 type EventOrchestrationPathIncidentCustomFieldUpdate struct {
 	ID    string `json:"id,omitempty"`
 	Value string `json:"value,omitempty"`
+}
+
+type EventOrchestrationPathEscalationPolicy struct {
+	EscalationPolicy string `json:"escalation_policy,omitempty"`
 }
 
 type EventOrchestrationPathPagerdutyAutomationAction struct {

--- a/pagerduty/event_orchestration_path.go
+++ b/pagerduty/event_orchestration_path.go
@@ -50,7 +50,6 @@ type EventOrchestrationPathRuleCondition struct {
 // Router: https://developer.pagerduty.com/api-reference/f0fae270c70b3-get-the-router-for-a-global-event-orchestration
 // Service: https://developer.pagerduty.com/api-reference/179537b835e2d-get-the-service-orchestration-for-a-service
 // Unrouted: https://developer.pagerduty.com/api-reference/70aa1139e1013-get-the-unrouted-orchestration-for-a-global-event-orchestration
-
 type EventOrchestrationPathRuleActions struct {
 	DropEvent                  bool                                               `json:"drop_event"`
 	RouteTo                    string                                             `json:"route_to"`

--- a/pagerduty/event_orchestration_path.go
+++ b/pagerduty/event_orchestration_path.go
@@ -50,6 +50,7 @@ type EventOrchestrationPathRuleCondition struct {
 // Router: https://developer.pagerduty.com/api-reference/f0fae270c70b3-get-the-router-for-a-global-event-orchestration
 // Service: https://developer.pagerduty.com/api-reference/179537b835e2d-get-the-service-orchestration-for-a-service
 // Unrouted: https://developer.pagerduty.com/api-reference/70aa1139e1013-get-the-unrouted-orchestration-for-a-global-event-orchestration
+
 type EventOrchestrationPathRuleActions struct {
 	DropEvent                  bool                                               `json:"drop_event"`
 	RouteTo                    string                                             `json:"route_to"`

--- a/pagerduty/event_orchestration_path.go
+++ b/pagerduty/event_orchestration_path.go
@@ -65,7 +65,7 @@ type EventOrchestrationPathRuleActions struct {
 	EventAction                string                                             `json:"event_action"`
 	Variables                  []*EventOrchestrationPathActionVariables           `json:"variables"`
 	Extractions                []*EventOrchestrationPathActionExtractions         `json:"extractions"`
-	EscalationPolicy           string                                             `json:"escalation_policy,omitempty"`
+	EscalationPolicy           string                                             `json:"escalation_policy"`
 }
 
 type EventOrchestrationPathDynamicRouteTo struct {

--- a/pagerduty/event_orchestration_path_test.go
+++ b/pagerduty/event_orchestration_path_test.go
@@ -506,7 +506,7 @@ func TestEventOrchestrationPathEscalationPolicyUpdate(t *testing.T) {
 		},
 	}
 
-	var url = fmt.Sprintf("%s/E-ORC-1/router", eventOrchestrationBaseUrl)
+	var url = fmt.Sprintf("%s/E-ORC-1/global", eventOrchestrationBaseUrl)
 
 	mux.HandleFunc(url, func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -515,16 +515,16 @@ func TestEventOrchestrationPathEscalationPolicyUpdate(t *testing.T) {
 		if !reflect.DeepEqual(v.OrchestrationPath, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
-		w.Write([]byte(`{ "orchestration_path": { "type": "router", "parent": { "id": "E-ORC-1", "self": "https://api.pagerduty.com/event_orchestrations/E-ORC-1", "type": "event_orchestration_reference" }, "sets": [ { "id": "start", "rules": [ { "actions": { "escalation_policy": "POLICY"}, "id": "E-ORC-EP-RULE" } ] } ] } }`))
+		w.Write([]byte(`{ "orchestration_path": { "type": "global", "parent": { "id": "E-ORC-1", "self": "https://api.pagerduty.com/event_orchestrations/E-ORC-1", "type": "event_orchestration_reference" }, "sets": [ { "id": "start", "rules": [ { "actions": { "escalation_policy": "POLICY"}, "id": "E-ORC-EP-RULE" } ] } ] } }`))
 	})
-	resp, _, err := client.EventOrchestrationPaths.Update("E-ORC-1", PathTypeRouter, input)
+	resp, _, err := client.EventOrchestrationPaths.Update("E-ORC-1", PathTypeGlobal, input)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	want := &EventOrchestrationPathPayload{
 		OrchestrationPath: &EventOrchestrationPath{
-			Type: "router",
+			Type: "global",
 			Parent: &EventOrchestrationPathReference{
 				ID:   "E-ORC-1",
 				Self: "https://api.pagerduty.com/event_orchestrations/E-ORC-1",

--- a/pagerduty/event_orchestration_path_test.go
+++ b/pagerduty/event_orchestration_path_test.go
@@ -522,6 +522,7 @@ func TestEventOrchestrationPathEscalationPolicyUpdate(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	policy := "POLICY"
 	want := &EventOrchestrationPathPayload{
 		OrchestrationPath: &EventOrchestrationPath{
 			Type: "global",
@@ -536,7 +537,7 @@ func TestEventOrchestrationPathEscalationPolicyUpdate(t *testing.T) {
 					Rules: []*EventOrchestrationPathRule{
 						{
 							Actions: &EventOrchestrationPathRuleActions{
-								EscalationPolicy: "POLICY",
+								EscalationPolicy: &policy,
 							},
 							ID: "E-ORC-EP-RULE",
 						},

--- a/pagerduty/event_orchestration_path_test.go
+++ b/pagerduty/event_orchestration_path_test.go
@@ -494,7 +494,7 @@ func TestEventOrchestrationPathGlobalUpdate(t *testing.T) {
 	}
 }
 
-func TestEventOrchestrationPathRouterUpdate(t *testing.T) {
+func TestEventOrchestrationPathEscalationPolicyUpdate(t *testing.T) {
 	setup()
 	defer teardown()
 	input := &EventOrchestrationPath{
@@ -515,9 +515,8 @@ func TestEventOrchestrationPathRouterUpdate(t *testing.T) {
 		if !reflect.DeepEqual(v.OrchestrationPath, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
-		w.Write([]byte(`{"orchestration_path": { "type": "router", "parent": { "id": "E-ORC-1", "self": "https://api.pagerduty.com/event_orchestrations/E-ORC-1", "type": "event_orchestration_reference" }, "sets": [ { "id": "start", "rules": [ { "actions": { "escalation_policy": "POLICY"}}, {"actions": { "dynamic_route_to": { "source": "event.summary", "regex": "service name: (.*)", "lookup_by": "service_name" }}, "conditions": [], "id": "E-ORC-DYNAMIC-RULE"}, { "actions": { "route_to": "P3ZQXDF" }, "conditions": [ { "expression": "event.summary matches part 'orca'" }, { "expression": "event.summary matches part 'humpback'" } ], "id": "E-ORC-RULE-1"}]}]}}`))
+		w.Write([]byte(`{ "orchestration_path": { "type": "router", "parent": { "id": "E-ORC-1", "self": "https://api.pagerduty.com/event_orchestrations/E-ORC-1", "type": "event_orchestration_reference" }, "sets": [ { "id": "start", "rules": [ { "actions": { "escalation_policy": "POLICY"}, "id": "E-ORC-EP-RULE" } ] } ] } }`))
 	})
-
 	resp, _, err := client.EventOrchestrationPaths.Update("E-ORC-1", PathTypeRouter, input)
 	if err != nil {
 		t.Fatal(err)
@@ -539,7 +538,61 @@ func TestEventOrchestrationPathRouterUpdate(t *testing.T) {
 							Actions: &EventOrchestrationPathRuleActions{
 								EscalationPolicy: "POLICY",
 							},
+							ID: "E-ORC-EP-RULE",
 						},
+					},
+				},
+			},
+		},
+		Warnings: nil,
+	}
+
+	if !reflect.DeepEqual(resp, want) {
+		t.Errorf("returned \n\n%#v want \n\n%#v", resp, want)
+	}
+}
+
+func TestEventOrchestrationPathRouterUpdate(t *testing.T) {
+	setup()
+	defer teardown()
+	input := &EventOrchestrationPath{
+		Type: "router",
+		Parent: &EventOrchestrationPathReference{
+			ID:   "E-ORC-1",
+			Self: "https://api.pagerduty.com/event_orchestrations/E-ORC-1",
+			Type: "event_orchestration_reference",
+		},
+	}
+
+	var url = fmt.Sprintf("%s/E-ORC-1/router", eventOrchestrationBaseUrl)
+
+	mux.HandleFunc(url, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		v := new(EventOrchestrationPathPayload)
+		json.NewDecoder(r.Body).Decode(v)
+		if !reflect.DeepEqual(v.OrchestrationPath, input) {
+			t.Errorf("Request body = %+v, want %+v", v, input)
+		}
+		w.Write([]byte(`{"orchestration_path": { "type": "router", "parent": { "id": "E-ORC-1", "self": "https://api.pagerduty.com/event_orchestrations/E-ORC-1", "type": "event_orchestration_reference" }, "sets": [ { "id": "start", "rules": [ {"actions": { "dynamic_route_to": { "source": "event.summary", "regex": "service name: (.*)", "lookup_by": "service_name" }}, "conditions": [], "id": "E-ORC-DYNAMIC-RULE"}, { "actions": { "route_to": "P3ZQXDF" }, "conditions": [ { "expression": "event.summary matches part 'orca'" }, { "expression": "event.summary matches part 'humpback'" } ], "id": "E-ORC-RULE-1"}]}]}}`))
+	})
+
+	resp, _, err := client.EventOrchestrationPaths.Update("E-ORC-1", PathTypeRouter, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &EventOrchestrationPathPayload{
+		OrchestrationPath: &EventOrchestrationPath{
+			Type: "router",
+			Parent: &EventOrchestrationPathReference{
+				ID:   "E-ORC-1",
+				Self: "https://api.pagerduty.com/event_orchestrations/E-ORC-1",
+				Type: "event_orchestration_reference",
+			},
+			Sets: []*EventOrchestrationPathSet{
+				{
+					ID: "start",
+					Rules: []*EventOrchestrationPathRule{
 						{
 							Actions: &EventOrchestrationPathRuleActions{
 								DynamicRouteTo: &EventOrchestrationPathDynamicRouteTo{

--- a/pagerduty/event_orchestration_path_test.go
+++ b/pagerduty/event_orchestration_path_test.go
@@ -515,7 +515,7 @@ func TestEventOrchestrationPathRouterUpdate(t *testing.T) {
 		if !reflect.DeepEqual(v.OrchestrationPath, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
-		w.Write([]byte(`{"orchestration_path": { "type": "router", "parent": { "id": "E-ORC-1", "self": "https://api.pagerduty.com/event_orchestrations/E-ORC-1", "type": "event_orchestration_reference" }, "sets": [ { "id": "start", "rules": [ { "actions": { "dynamic_route_to": { "source": "event.summary", "regex": "service name: (.*)", "lookup_by": "service_name" }}, "conditions": [], "id": "E-ORC-DYNAMIC-RULE"}, { "actions": { "route_to": "P3ZQXDF" }, "conditions": [ { "expression": "event.summary matches part 'orca'" }, { "expression": "event.summary matches part 'humpback'" } ], "id": "E-ORC-RULE-1"}]}]}}`))
+		w.Write([]byte(`{"orchestration_path": { "type": "router", "parent": { "id": "E-ORC-1", "self": "https://api.pagerduty.com/event_orchestrations/E-ORC-1", "type": "event_orchestration_reference" }, "sets": [ { "id": "start", "rules": [ { "actions": { "escalation_policy": "POLICY"}}, {"actions": { "dynamic_route_to": { "source": "event.summary", "regex": "service name: (.*)", "lookup_by": "service_name" }}, "conditions": [], "id": "E-ORC-DYNAMIC-RULE"}, { "actions": { "route_to": "P3ZQXDF" }, "conditions": [ { "expression": "event.summary matches part 'orca'" }, { "expression": "event.summary matches part 'humpback'" } ], "id": "E-ORC-RULE-1"}]}]}}`))
 	})
 
 	resp, _, err := client.EventOrchestrationPaths.Update("E-ORC-1", PathTypeRouter, input)
@@ -535,6 +535,11 @@ func TestEventOrchestrationPathRouterUpdate(t *testing.T) {
 				{
 					ID: "start",
 					Rules: []*EventOrchestrationPathRule{
+						{
+							Actions: &EventOrchestrationPathRuleActions{
+								EscalationPolicy: "POLICY",
+							},
+						},
 						{
 							Actions: &EventOrchestrationPathRuleActions{
 								DynamicRouteTo: &EventOrchestrationPathDynamicRouteTo{

--- a/pagerduty/event_orchestration_path_test.go
+++ b/pagerduty/event_orchestration_path_test.go
@@ -515,7 +515,7 @@ func TestEventOrchestrationPathRouterUpdate(t *testing.T) {
 		if !reflect.DeepEqual(v.OrchestrationPath, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
-		w.Write([]byte(`{"orchestration_path": { "type": "router", "parent": { "id": "E-ORC-1", "self": "https://api.pagerduty.com/event_orchestrations/E-ORC-1", "type": "event_orchestration_reference" }, "sets": [ { "id": "start", "rules": [ { "actions": { "route_to": "P3ZQXDF" }, "conditions": [ { "expression": "event.summary matches part 'orca'" }, { "expression": "event.summary matches part 'humpback'" } ], "id": "E-ORC-RULE-1"}]}]}}`))
+		w.Write([]byte(`{"orchestration_path": { "type": "router", "parent": { "id": "E-ORC-1", "self": "https://api.pagerduty.com/event_orchestrations/E-ORC-1", "type": "event_orchestration_reference" }, "sets": [ { "id": "start", "rules": [ { "actions": { "dynamic_route_to": { "source": "event.summary", "regex": "service name: (.*)", "lookup_by": "service_name" }}, "conditions": [], "id": "E-ORC-DYNAMIC-RULE"}, { "actions": { "route_to": "P3ZQXDF" }, "conditions": [ { "expression": "event.summary matches part 'orca'" }, { "expression": "event.summary matches part 'humpback'" } ], "id": "E-ORC-RULE-1"}]}]}}`))
 	})
 
 	resp, _, err := client.EventOrchestrationPaths.Update("E-ORC-1", PathTypeRouter, input)
@@ -535,6 +535,17 @@ func TestEventOrchestrationPathRouterUpdate(t *testing.T) {
 				{
 					ID: "start",
 					Rules: []*EventOrchestrationPathRule{
+						{
+							Actions: &EventOrchestrationPathRuleActions{
+								DynamicRouteTo: &EventOrchestrationPathDynamicRouteTo{
+									Source:   "event.summary",
+									Regex:    "service name: (.*)",
+									LookupBy: "service_name",
+								},
+							},
+							Conditions: []*EventOrchestrationPathRuleCondition{},
+							ID:         "E-ORC-DYNAMIC-RULE",
+						},
 						{
 							Actions: &EventOrchestrationPathRuleActions{
 								RouteTo: "P3ZQXDF",

--- a/pagerduty/event_orchestration_path_test.go
+++ b/pagerduty/event_orchestration_path_test.go
@@ -498,7 +498,7 @@ func TestEventOrchestrationPathEscalationPolicyUpdate(t *testing.T) {
 	setup()
 	defer teardown()
 	input := &EventOrchestrationPath{
-		Type: "router",
+		Type: "global",
 		Parent: &EventOrchestrationPathReference{
 			ID:   "E-ORC-1",
 			Self: "https://api.pagerduty.com/event_orchestrations/E-ORC-1",


### PR DESCRIPTION
This PR includes support for 2 new rule actions: `dynamic route to` and `escalation policy assignment` for Event Orchestration

### Changes:
1.  Support for `dynamic_route_to` action on the Router Event Orchestration Path.
2. Client supports CRUDing an `escalation_policy` action for Global and Service Orchestration Paths.
