### PR TITLE
AA-1837 add only_invocable_on_unresolved_incidents option to automation actions

### DIFF
--- a/pagerduty/automation_actions_action.go
+++ b/pagerduty/automation_actions_action.go
@@ -21,7 +21,7 @@ type AutomationActionsAction struct {
 	RunnerType                         *string                              `json:"runner_type,omitempty"`
 	CreationTime                       *string                              `json:"creation_time,omitempty"`
 	ModifyTime                         *string                              `json:"modify_time,omitempty"`
-	OnlyInvocableOnUnresolvedIncidents bool                                 `json:"only_invocable_on_unresolved_incidents"`
+	OnlyInvocableOnUnresolvedIncidents *bool                                `json:"only_invocable_on_unresolved_incidents,omitempty"`
 }
 
 type AutomationActionsActionDataReference struct {

--- a/pagerduty/automation_actions_action.go
+++ b/pagerduty/automation_actions_action.go
@@ -21,7 +21,7 @@ type AutomationActionsAction struct {
 	RunnerType                         *string                              `json:"runner_type,omitempty"`
 	CreationTime                       *string                              `json:"creation_time,omitempty"`
 	ModifyTime                         *string                              `json:"modify_time,omitempty"`
-	OnlyInvocableOnUnresolvedIncidents bool                                 `json:"only_invocable_on_unresolved_incidents,omitempty"`
+	OnlyInvocableOnUnresolvedIncidents bool                                 `json:"only_invocable_on_unresolved_incidents"`
 }
 
 type AutomationActionsActionDataReference struct {

--- a/pagerduty/automation_actions_action.go
+++ b/pagerduty/automation_actions_action.go
@@ -7,20 +7,21 @@ import "fmt"
 type AutomationActionsActionService service
 
 type AutomationActionsAction struct {
-	ID                   string                               `json:"id"`
-	Name                 string                               `json:"name"`
-	Description          *string                              `json:"description,omitempty"`
-	ActionType           string                               `json:"action_type"`
-	RunnerID             *string                              `json:"runner,omitempty"`
-	ActionDataReference  AutomationActionsActionDataReference `json:"action_data_reference"`
-	Services             []*ServiceReference                  `json:"services,omitempty"`
-	Teams                []*TeamReference                     `json:"teams,omitempty"`
-	Privileges           *AutomationActionsPrivileges         `json:"privileges,omitempty"`
-	Type                 *string                              `json:"type,omitempty"`
-	ActionClassification *string                              `json:"action_classification,omitempty"`
-	RunnerType           *string                              `json:"runner_type,omitempty"`
-	CreationTime         *string                              `json:"creation_time,omitempty"`
-	ModifyTime           *string                              `json:"modify_time,omitempty"`
+	ID                                 string                               `json:"id"`
+	Name                               string                               `json:"name"`
+	Description                        *string                              `json:"description,omitempty"`
+	ActionType                         string                               `json:"action_type"`
+	RunnerID                           *string                              `json:"runner,omitempty"`
+	ActionDataReference                AutomationActionsActionDataReference `json:"action_data_reference"`
+	Services                           []*ServiceReference                  `json:"services,omitempty"`
+	Teams                              []*TeamReference                     `json:"teams,omitempty"`
+	Privileges                         *AutomationActionsPrivileges         `json:"privileges,omitempty"`
+	Type                               *string                              `json:"type,omitempty"`
+	ActionClassification               *string                              `json:"action_classification,omitempty"`
+	RunnerType                         *string                              `json:"runner_type,omitempty"`
+	CreationTime                       *string                              `json:"creation_time,omitempty"`
+	ModifyTime                         *string                              `json:"modify_time,omitempty"`
+	OnlyInvocableOnUnresolvedIncidents bool                                 `json:"only_invocable_on_unresolved_incidents,omitempty"`
 }
 
 type AutomationActionsActionDataReference struct {

--- a/pagerduty/automation_actions_action_test.go
+++ b/pagerduty/automation_actions_action_test.go
@@ -93,17 +93,19 @@ func TestAutomationActionsActionTypeProcessAutomationCreate(t *testing.T) {
 	adf_arg := "-arg 123"
 	adf_node_filter := "tags: production"
 	job_id := "1519578e-a22a-4340-b58f-08194691e10b"
+	only_invocable_on_unresolved_incidents := true
 	adf := AutomationActionsActionDataReference{
 		ProcessAutomationJobId:        &job_id,
 		ProcessAutomationJobArguments: &adf_arg,
 		ProcessAutomationNodeFilter:   &adf_node_filter,
 	}
 	input := &AutomationActionsAction{
-		Name:                "Action created by TF",
-		Description:         &description,
-		ActionType:          "process_automation",
-		RunnerID:            &runner_id,
-		ActionDataReference: adf,
+		Name:                               "Action created by TF",
+		Description:                        &description,
+		ActionType:                         "process_automation",
+		RunnerID:                           &runner_id,
+		ActionDataReference:                adf,
+		OnlyInvocableOnUnresolvedIncidents: only_invocable_on_unresolved_incidents,
 	}
 
 	mux.HandleFunc("/automation_actions/actions", func(w http.ResponseWriter, r *http.Request) {
@@ -113,7 +115,7 @@ func TestAutomationActionsActionTypeProcessAutomationCreate(t *testing.T) {
 		if !reflect.DeepEqual(v.Action, input) {
 			t.Errorf("Request body = %+v, want %+v", v.Action, input)
 		}
-		w.Write([]byte(`{"action":{"action_data_reference":{"process_automation_job_id":"1519578e-a22a-4340-b58f-08194691e10b","process_automation_job_arguments":"-arg 123", "process_automation_node_filter":"tags: production"},"action_type":"process_automation","creation_time":"2022-12-12T18:51:42.048162Z","description":"Description of Action created by TF","id":"01DF4OBNYKW84FS9CCYVYS1MOS","last_run":"2022-12-12T18:52:11.937747Z","last_run_by":{"id":"PINL781","type":"user_reference"},"modify_time":"2022-12-12T18:51:42.048162Z","name":"Action created by TF","privileges":{"permissions":["read"]},"runner":"01DF4O9T1MDPYOUT7SUX9EXZ4R","runner_type":"runbook","services":[{"id":"PQWQ0U6","type":"service_reference"}],"teams":[{"id":"PZ31N6S","type":"team_reference"}],"type":"action"}}`))
+		w.Write([]byte(`{"action":{"only_invocable_on_unresolved_incidents":true,"action_data_reference":{"process_automation_job_id":"1519578e-a22a-4340-b58f-08194691e10b","process_automation_job_arguments":"-arg 123", "process_automation_node_filter":"tags: production"},"action_type":"process_automation","creation_time":"2022-12-12T18:51:42.048162Z","description":"Description of Action created by TF","id":"01DF4OBNYKW84FS9CCYVYS1MOS","last_run":"2022-12-12T18:52:11.937747Z","last_run_by":{"id":"PINL781","type":"user_reference"},"modify_time":"2022-12-12T18:51:42.048162Z","name":"Action created by TF","privileges":{"permissions":["read"]},"runner":"01DF4O9T1MDPYOUT7SUX9EXZ4R","runner_type":"runbook","services":[{"id":"PQWQ0U6","type":"service_reference"}],"teams":[{"id":"PZ31N6S","type":"team_reference"}],"type":"action"}}`))
 	})
 
 	resp, _, err := client.AutomationActionsAction.Create(input)
@@ -152,6 +154,7 @@ func TestAutomationActionsActionTypeProcessAutomationCreate(t *testing.T) {
 			Permissions: []*string{&permissions_read},
 		},
 		ModifyTime: &modify_time,
+		OnlyInvocableOnUnresolvedIncidents: only_invocable_on_unresolved_incidents,
 	}
 
 	if !reflect.DeepEqual(resp, want) {
@@ -168,17 +171,19 @@ func TestAutomationActionsActionUpdate(t *testing.T) {
 	adf_arg := "-arg 123"
 	adf_node_filter := "tags: production"
 	job_id := "1519578e-a22a-4340-b58f-08194691e10b"
+	only_invocable_on_unresolved_incidents := true
 	adf := AutomationActionsActionDataReference{
 		ProcessAutomationJobId:        &job_id,
 		ProcessAutomationJobArguments: &adf_arg,
 		ProcessAutomationNodeFilter:   &adf_node_filter,
 	}
 	input := &AutomationActionsAction{
-		Name:                "Action created by TF",
-		Description:         &description,
-		ActionType:          "process_automation",
-		RunnerID:            &runner_id,
-		ActionDataReference: adf,
+		Name:                               "Action created by TF",
+		Description:                        &description,
+		ActionType:                         "process_automation",
+		RunnerID:                           &runner_id,
+		ActionDataReference:                adf,
+		OnlyInvocableOnUnresolvedIncidents: only_invocable_on_unresolved_incidents,
 	}
 
 	var id = "01DF4OBNYKW84FS9CCYVYS1MOS"
@@ -191,7 +196,7 @@ func TestAutomationActionsActionUpdate(t *testing.T) {
 		if !reflect.DeepEqual(v.Action, input) {
 			t.Errorf("Request body = %+v, want %+v", v.Action, input)
 		}
-		w.Write([]byte(`{"action":{"action_data_reference":{"process_automation_job_id":"1519578e-a22a-4340-b58f-08194691e10b","process_automation_job_arguments":"-arg 123", "process_automation_node_filter":"tags: production"},"action_type":"process_automation","creation_time":"2022-12-12T18:51:42.048162Z","description":"Description of Action created by TF","id":"01DF4OBNYKW84FS9CCYVYS1MOS","last_run":"2022-12-12T18:52:11.937747Z","last_run_by":{"id":"PINL781","type":"user_reference"},"modify_time":"2022-12-12T18:51:42.048162Z","name":"Action created by TF","privileges":{"permissions":["read"]},"runner":"01DF4O9T1MDPYOUT7SUX9EXZ4R","runner_type":"runbook","services":[{"id":"PQWQ0U6","type":"service_reference"}],"teams":[{"id":"PZ31N6S","type":"team_reference"}],"type":"action"}}`))
+		w.Write([]byte(`{"action":{"only_invocable_on_unresolved_incidents":true,"action_data_reference":{"process_automation_job_id":"1519578e-a22a-4340-b58f-08194691e10b","process_automation_job_arguments":"-arg 123", "process_automation_node_filter":"tags: production"},"action_type":"process_automation","creation_time":"2022-12-12T18:51:42.048162Z","description":"Description of Action created by TF","id":"01DF4OBNYKW84FS9CCYVYS1MOS","last_run":"2022-12-12T18:52:11.937747Z","last_run_by":{"id":"PINL781","type":"user_reference"},"modify_time":"2022-12-12T18:51:42.048162Z","name":"Action created by TF","privileges":{"permissions":["read"]},"runner":"01DF4O9T1MDPYOUT7SUX9EXZ4R","runner_type":"runbook","services":[{"id":"PQWQ0U6","type":"service_reference"}],"teams":[{"id":"PZ31N6S","type":"team_reference"}],"type":"action"}}`))
 	})
 
 	resp, _, err := client.AutomationActionsAction.Update(id, input)
@@ -230,6 +235,7 @@ func TestAutomationActionsActionUpdate(t *testing.T) {
 			Permissions: []*string{&permissions_read},
 		},
 		ModifyTime: &modify_time,
+		OnlyInvocableOnUnresolvedIncidents: only_invocable_on_unresolved_incidents,
 	}
 
 	if !reflect.DeepEqual(resp, want) {
@@ -259,16 +265,18 @@ func TestAutomationActionsActionTypeScriptCreate(t *testing.T) {
 	runner_id := "01DF4O9T1MDPYOUT7SUX9EXZ4R"
 	invocation_command := "/bin/bash"
 	script_data := "java --version"
+	only_invocable_on_unresolved_incidents := true
 	adf := AutomationActionsActionDataReference{
 		Script:            &script_data,
 		InvocationCommand: &invocation_command,
 	}
 	input := &AutomationActionsAction{
-		Name:                "Action created by TF",
-		Description:         &description,
-		ActionType:          "script",
-		RunnerID:            &runner_id,
-		ActionDataReference: adf,
+		Name:                               "Action created by TF",
+		Description:                        &description,
+		ActionType:                         "script",
+		RunnerID:                           &runner_id,
+		ActionDataReference:                adf,
+		OnlyInvocableOnUnresolvedIncidents: only_invocable_on_unresolved_incidents,
 	}
 
 	mux.HandleFunc("/automation_actions/actions", func(w http.ResponseWriter, r *http.Request) {

--- a/pagerduty/automation_actions_action_test.go
+++ b/pagerduty/automation_actions_action_test.go
@@ -105,7 +105,7 @@ func TestAutomationActionsActionTypeProcessAutomationCreate(t *testing.T) {
 		ActionType:                         "process_automation",
 		RunnerID:                           &runner_id,
 		ActionDataReference:                adf,
-		OnlyInvocableOnUnresolvedIncidents: only_invocable_on_unresolved_incidents,
+		OnlyInvocableOnUnresolvedIncidents: &only_invocable_on_unresolved_incidents,
 	}
 
 	mux.HandleFunc("/automation_actions/actions", func(w http.ResponseWriter, r *http.Request) {
@@ -153,8 +153,8 @@ func TestAutomationActionsActionTypeProcessAutomationCreate(t *testing.T) {
 		Privileges: &AutomationActionsPrivileges{
 			Permissions: []*string{&permissions_read},
 		},
-		ModifyTime: &modify_time,
-		OnlyInvocableOnUnresolvedIncidents: only_invocable_on_unresolved_incidents,
+		ModifyTime:                         &modify_time,
+		OnlyInvocableOnUnresolvedIncidents: &only_invocable_on_unresolved_incidents,
 	}
 
 	if !reflect.DeepEqual(resp, want) {
@@ -183,7 +183,7 @@ func TestAutomationActionsActionUpdate(t *testing.T) {
 		ActionType:                         "process_automation",
 		RunnerID:                           &runner_id,
 		ActionDataReference:                adf,
-		OnlyInvocableOnUnresolvedIncidents: only_invocable_on_unresolved_incidents,
+		OnlyInvocableOnUnresolvedIncidents: &only_invocable_on_unresolved_incidents,
 	}
 
 	var id = "01DF4OBNYKW84FS9CCYVYS1MOS"
@@ -234,8 +234,8 @@ func TestAutomationActionsActionUpdate(t *testing.T) {
 		Privileges: &AutomationActionsPrivileges{
 			Permissions: []*string{&permissions_read},
 		},
-		ModifyTime: &modify_time,
-		OnlyInvocableOnUnresolvedIncidents: only_invocable_on_unresolved_incidents,
+		ModifyTime:                         &modify_time,
+		OnlyInvocableOnUnresolvedIncidents: &only_invocable_on_unresolved_incidents,
 	}
 
 	if !reflect.DeepEqual(resp, want) {
@@ -276,7 +276,7 @@ func TestAutomationActionsActionTypeScriptCreate(t *testing.T) {
 		ActionType:                         "script",
 		RunnerID:                           &runner_id,
 		ActionDataReference:                adf,
-		OnlyInvocableOnUnresolvedIncidents: only_invocable_on_unresolved_incidents,
+		OnlyInvocableOnUnresolvedIncidents: &only_invocable_on_unresolved_incidents,
 	}
 
 	mux.HandleFunc("/automation_actions/actions", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Adds new field `only_invocable_on_unresolved_incidents` to Automation Action's schema.
