### PR TITLE
Allow null and omitted service.alert_grouping by double indirection

### DIFF
--- a/pagerduty/service.go
+++ b/pagerduty/service.go
@@ -133,7 +133,7 @@ type Service struct {
 	AcknowledgementTimeout           *int                              `json:"acknowledgement_timeout"`
 	Addons                           []*AddonReference                 `json:"addons,omitempty"`
 	AlertCreation                    string                            `json:"alert_creation,omitempty"`
-	AlertGrouping                    *string                           `json:"alert_grouping"`
+	AlertGrouping                    **string                          `json:"alert_grouping,omitempty"`
 	AlertGroupingTimeout             *int                              `json:"alert_grouping_timeout,omitempty"`
 	AlertGroupingParameters          *AlertGroupingParameters          `json:"alert_grouping_parameters,omitempty"`
 	AutoPauseNotificationsParameters *AutoPauseNotificationsParameters `json:"auto_pause_notifications_parameters,omitempty"`

--- a/pagerduty/service_fixtures_test.go
+++ b/pagerduty/service_fixtures_test.go
@@ -146,14 +146,16 @@ var (
 	defaultAutoResolveTimeout                = 14400
 	defaultPosition                          = 0
 
-	ag                        = "intelligent"
+	ag    = "intelligent"
+	agPtr = &ag
+
 	validListServicesResponse = &ListServicesResponse{
 		Services: []*Service{
-			&Service{
+			{
 				AcknowledgementTimeout: &defaultTestServiceAcknowledgementTimeout,
 				Addons:                 nil,
 				AlertCreation:          "create_alerts_and_incidents",
-				AlertGrouping:          &ag,
+				AlertGrouping:          &agPtr,
 				AlertGroupingTimeout:   nil,
 				AutoResolveTimeout:     &defaultAutoResolveTimeout,
 				CreatedAt:              "2015-11-06T11:12:51-05:00",


### PR DESCRIPTION
BREAKING CHANGE: Service.AlertGrouping is now a **string