### PR TITLE
Don't omit 'inputs' field in pagerduty_incident_workflow as it's required by the API

### DIFF
--- a/pagerduty/incident_workflow.go
+++ b/pagerduty/incident_workflow.go
@@ -34,7 +34,7 @@ type IncidentWorkflowStep struct {
 type IncidentWorkflowActionConfiguration struct {
 	ActionID          string                                    `json:"action_id,omitempty"`
 	Description       *string                                   `json:"description,omitempty"`
-	Inputs            []*IncidentWorkflowActionInput            `json:"inputs,omitempty"`
+	Inputs            []*IncidentWorkflowActionInput            `json:"inputs"`
 	InlineStepsInputs []*IncidentWorkflowActionInlineStepsInput `json:"inline_steps_inputs,omitempty"`
 }
 


### PR DESCRIPTION
Currently, the client omits fields that are empty when serializing to JSON. However, the API endpoint `https://api.pagerduty.com/incident_workflows/id`, which is used for updating Incident Workflows, requires that the field `inputs` exists in the payload. This makes it so that you cannot use the create zoom room action (or any others that do not have an input) without a 'fake' input.

This also addresses the issue in https://github.com/PagerDuty/terraform-provider-pagerduty/issues/840

**API Response without the inputs defined**
```py
import requests

url = "https://api.pagerduty.com/incident_workflows/id"

payload = { "incident_workflow": {
        "name": "Example Incident Workflow",
        "description": "This Incident Workflow is an example",
        "steps": [
            {
                "name": "Send Status Update",
                "action_configuration": {
                    "action_id": "pagerduty.com:incident-workflows:send-status-update:1",
                }
            }
        ]
    } }
headers = {
    "Accept": "application/json",
    "Content-Type": "application/json",
    "Authorization": "Token token=---------"
}

response = requests.put(url, json=payload, headers=headers)

print(response.json())

> {'message': 'Invalid body: "incident_workflow.steps[0].action_configuration.inputs" is required'}
```

This is copied from my PR in the terraform provider which uses this client- https://github.com/PagerDuty/terraform-provider-pagerduty/pull/992.