### PR TITLE
Remove omitempty from type in AlertGroupingParameters

### DIFF
--- a/pagerduty/service.go
+++ b/pagerduty/service.go
@@ -46,7 +46,7 @@ type AlertGroupingConfig struct {
 
 // AlertGroupingParameters defines how alerts are grouped into incidents
 type AlertGroupingParameters struct {
-	Type   *string              `json:"type,omitempty"`
+	Type   *string              `json:"type"`
 	Config *AlertGroupingConfig `json:"config,omitempty"`
 }
 


### PR DESCRIPTION
Remove omitempty from `type` to allow turning off

<img width="686" height="213" alt="image" src="https://github.com/user-attachments/assets/e469517d-ed6b-4de2-9316-8685449f242d" />
